### PR TITLE
Add json body parser to API base app

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const morgan = require('morgan');
+const bodyParser = require('body-parser');
 
 const auth = require('../lib/auth');
 const normalise = require('../lib/settings');
@@ -15,6 +16,8 @@ module.exports = settings => {
     app.use(keycloak.middleware());
     app.protect = rules => app.use(keycloak.protect(rules));
   }
+
+  app.use(bodyParser.json());
 
   return app;
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-service#readme",
   "dependencies": {
     "@lennym/redis-session": "^1.0.4",
+    "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "express-react-views": "^0.10.5",
     "express-session": "^1.15.6",


### PR DESCRIPTION
We're always going to want JSON parsing in API instances so add it in here.