### PR TITLE
Add a configurable logger to service template

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,15 +1,15 @@
 const express = require('express');
-const morgan = require('morgan');
 const bodyParser = require('body-parser');
 
 const auth = require('../lib/auth');
 const normalise = require('../lib/settings');
+const logger = require('../lib/logger');
 
 module.exports = settings => {
   settings = normalise(settings);
   const app = express();
 
-  app.use(morgan(settings.logformat));
+  app.use(logger(settings));
 
   if (settings.auth) {
     const keycloak = auth(Object.assign(settings.auth, { bearerOnly: true }));

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -30,7 +30,7 @@ module.exports = settings => {
         level = 'info';
       }
       logger.log(level, msg);
-    }
+    };
     next();
   });
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,39 @@
+const winston = require('winston');
+const morgan = require('morgan');
+const { Router } = require('express');
+
+module.exports = settings => {
+
+  const options = { level: 'info', ...settings.log };
+
+  const router = Router();
+
+  const transports = [
+    new winston.transports.Console({
+      level: options.level || 'info'
+    })
+  ];
+
+  const logger = new winston.Logger({
+    transports
+  });
+
+  logger.stream = {
+    write: msg => logger.log('info', msg)
+  };
+
+  router.use(morgan(options.format, { stream: logger.stream }));
+  router.use((req, res, next) => {
+    req.log = (level, msg) => {
+      if (msg === undefined) {
+        msg = level;
+        level = 'info';
+      }
+      logger.log(level, msg);
+    }
+    next();
+  });
+
+  return router;
+
+};

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,9 +1,12 @@
-const clone = require('lodash.clonedeep');
+const { cloneDeep, merge } = require('lodash');
 
 module.exports = settings => {
-  settings = clone(settings);
-  return Object.assign({
-    logformat: 'dev',
+  settings = cloneDeep(settings);
+  return merge({
+    log: {
+      level: 'info',
+      format: 'dev'
+    },
     root: process.cwd()
   }, settings);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,11 @@
         "minimalistic-assert": "1.0.0"
       }
     },
+    "async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -176,7 +181,7 @@
         "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -204,7 +209,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       },
@@ -255,7 +260,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -314,7 +319,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -427,7 +432,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -753,7 +758,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.3",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       }
@@ -776,7 +781,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "babel-traverse": {
@@ -792,7 +797,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "debug": {
@@ -812,7 +817,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -1121,6 +1126,11 @@
         }
       }
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -1313,7 +1323,7 @@
         "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -1487,7 +1497,7 @@
         "eslint-import-resolver-node": "0.3.2",
         "eslint-module-utils": "2.2.0",
         "has": "1.0.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "read-pkg-up": "2.0.0",
         "resolve": "1.7.1"
@@ -1720,6 +1730,11 @@
         "iconv-lite": "0.4.19",
         "tmp": "0.0.33"
       }
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -2074,7 +2089,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -2266,6 +2281,11 @@
         "whatwg-fetch": "2.0.3"
       }
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-beautify": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
@@ -2382,20 +2402,15 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3233,6 +3248,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -3308,7 +3328,7 @@
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.3.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
@@ -3463,6 +3483,26 @@
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
+      }
+    },
+    "winston": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
+      "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        }
       }
     },
     "wordwrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -890,6 +890,12 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserslist": {
       "version": "2.11.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
@@ -1188,6 +1194,12 @@
         "repeating": "2.0.1"
       }
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1393,9 +1405,9 @@
       }
     },
     "eslint-config-lennym": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-lennym/-/eslint-config-lennym-2.0.0.tgz",
-      "integrity": "sha512-oeusONmBIPjf88H1SpShdHm/1bVPbwd/9wpoe0XrL8SQnducCcxbvaaif/YVUdosWE/cfy3qZQr2AvRXPbuxWA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-lennym/-/eslint-config-lennym-2.0.1.tgz",
+      "integrity": "sha512-3j6chn7bm26A50DscYxAsMgXB1GC2GAbipGia4q1L6rhY317+sEepUkOb1rebymVUy6mKjjafJofB/Q15X6RmA==",
       "dev": true,
       "requires": {
         "eslint-config-semistandard": "11.0.0",
@@ -1960,6 +1972,12 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -1991,6 +2009,12 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -2519,6 +2543,48 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
+      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "morgan": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "govuk-react-components": "^0.2.1",
     "govuk_frontend_toolkit": "^7.4.1",
     "keycloak-connect": "^3.4.3",
-    "lodash.clonedeep": "^4.5.0",
+    "lodash": "^4.17.5",
     "morgan": "^1.9.0",
     "r2": "^2.0.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "winston": "^2.4.2"
   },
   "publishConfig": {
     "registry": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "style": "ui/assets/default.scss",
   "scripts": {
-    "test": "eslint ."
+    "test": "npm run test:lint && npm run test:unit",
+    "test:lint": "eslint .",
+    "test:unit": "mocha ./Test --recursive"
   },
   "repository": {
     "type": "git",
@@ -39,6 +41,7 @@
   },
   "devDependencies": {
     "eslint": "^4.19.1",
-    "eslint-config-lennym": "^2.0.0"
+    "eslint-config-lennym": "^2.0.1",
+    "mocha": "^5.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
-    "test:unit": "mocha ./Test --recursive"
+    "test:unit": "mocha ./test --recursive"
   },
   "repository": {
     "type": "git",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+extends:
+  - "../.eslintrc"
+
+env:
+  mocha: true

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,9 @@
+const Api = require('../api');
+
+describe('api', () => {
+
+  it('can initialise without error', () => {
+    return Api({});
+  });
+
+});

--- a/test/ui.js
+++ b/test/ui.js
@@ -1,0 +1,9 @@
+const UI = require('../ui');
+
+describe('ui', () => {
+
+  it('can initialise without error', () => {
+    return UI({});
+  });
+
+});

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const morgan = require('morgan');
 const path = require('path');
 
 const { MemoryStore } = require('express-session');
@@ -11,6 +10,7 @@ const views = require('express-react-views');
 const auth = require('../lib/auth');
 const api = require('../lib/api');
 const normalise = require('../lib/settings');
+const logger = require('../lib/logger');
 
 const toolkitDir = path.dirname(require.resolve('govuk_frontend_toolkit/package.json'));
 const imagesDir = path.resolve(toolkitDir, './images');
@@ -40,7 +40,7 @@ module.exports = settings => {
     app.use('/public', express.static(settings.assets));
   }
 
-  app.use(morgan(settings.logformat));
+  app.use(logger(settings));
 
   if (settings.session) {
     app.use(session(settings.session));


### PR DESCRIPTION
This allows services implementing the templates to do customisable logging rather than just dumping everything to `console.log` (which makes testing noisy).

Instead expose a winston instance on `req.log` and wire the existing morgan implementation into this.