### PR TITLE
Allow nested pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
     "test:lint": "eslint .",
     "test:unit": "mocha ./test --recursive",
     "build": "npm run build:js && npm run build:css",
-    "prebuild:js": "mkdir -p ./pages/common/assets/.js",
     "build:js": "webpack",
-    "postbuild:js": "rm -rf ./pages/common/assets/.js",
+    "postbuild:js": "rm ./pages/**/dist/entry.js",
     "prebuild:css": "mkdir -p ./pages/common/dist/css",
     "build:css": "npm-sass ./pages/common/assets/sass/style.scss > ./pages/common/dist/css/app.css",
     "prepublish": "npm run build"
@@ -62,11 +61,13 @@
     "babel-preset-es2015": "^6.24.1",
     "eslint": "^4.19.1",
     "eslint-config-lennym": "^2.0.1",
+    "glob": "^7.1.2",
+    "mkdirp": "^0.5.1",
     "mocha": "^5.1.1",
     "npm-sass": "^2.2.3",
     "redux-logger": "^3.0.6",
-    "webpack-cli": "^2.1.3",
-    "webpack": "^4.8.3"
+    "webpack": "^4.8.3",
+    "webpack-cli": "^2.1.3"
   },
   "files": [
     "pages/*",

--- a/pages/common/assets/js/template.jsx
+++ b/pages/common/assets/js/template.jsx
@@ -7,8 +7,8 @@ import { stringify } from 'qs';
 import { render } from 'react-dom';
 import { applyMiddleware, createStore, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
-import Component from '../../../{{page}}/views';
-import allReducers from '../../../../lib/reducers';
+import Component from '{{page}}';
+import allReducers from '{{root}}/lib/reducers';
 
 const persistState = store => next => action => {
   const result = next(action);

--- a/ui/index.js
+++ b/ui/index.js
@@ -50,7 +50,7 @@ module.exports = settings => {
     app.use('/public', express.static(settings.assets));
   }
 
-  app.use('/public', express.static(path.resolve(__dirname, '../pages/common/dist')));
+  app.use('/public/js', express.static(path.resolve(__dirname, '../pages/common/dist')));
 
   app.use(logger(settings));
 


### PR DESCRIPTION
This does a glob and then renders a template into each page's `dist` directory, before compiling in situ. This means we don't need to have all pages at the same level in the directory tree and can nest pages inside child directories.