### PR TITLE
Swap pages from apps to routers

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const express = require('express');
-const expressViews = require('express-react-views');
 const persistQuery = require('./middleware/persist-query');
 const { combineReducers, createStore } = require('redux');
 const allReducers = require('../lib/reducers');
@@ -12,12 +11,7 @@ module.exports = ({
   root,
   schema
 }) => {
-  const app = express();
-
-  app.set('view engine', 'jsx');
-  app.engine('jsx', expressViews.createEngine({
-    transformViews: false
-  }));
+  const app = express.Router();
 
   app.use('/assets', express.static(path.resolve(root, './dist')));
 


### PR DESCRIPTION
We don't need to create new config scopes for each page now, so we can remove the overhead of creating new apps for each page. Use a basic router instead.