### PR TITLE
Use common views directory

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -8,6 +8,11 @@ const setData = data => ({
   data
 });
 
+const setSchema = schema => ({
+  type: 'SET_SCHEMA',
+  schema
+});
+
 const setUrl = url => ({
   type: 'SET_URL',
   url
@@ -15,6 +20,7 @@ const setUrl = url => ({
 
 module.exports = {
   setData,
+  setSchema,
   setEstablishment,
   setUrl
 };

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,10 +1,8 @@
-const path = require('path');
-
 module.exports = () => {
   return (error, req, res, next) => {
     if (error.status) {
       res.status(error.status);
     }
-    res.render(path.resolve(__dirname, '../pages/common/views/error'), { error });
+    res.render('error', { error });
   };
 };

--- a/lib/page.js
+++ b/lib/page.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const express = require('express');
-const expressViews = require('express-react-views');
 const persistQuery = require('./middleware/persist-query');
 const { combineReducers, createStore } = require('redux');
 const allReducers = require('../lib/reducers');
@@ -12,12 +11,7 @@ module.exports = ({
   root,
   schema
 }) => {
-  const app = express();
-
-  app.set('view engine', 'jsx');
-  app.engine('jsx', expressViews.createEngine({
-    transformViews: false
-  }));
+  const app = express.Router();
 
   app.use('/assets', express.static(path.resolve(root, './dist')));
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -1,12 +1,10 @@
 const path = require('path');
 const express = require('express');
 const persistQuery = require('./middleware/persist-query');
-const { combineReducers, createStore } = require('redux');
-const allReducers = require('../lib/reducers');
+const actions = require('../lib/actions');
 
 module.exports = ({
   name,
-  apiPath,
   reducers,
   root,
   schema
@@ -17,20 +15,7 @@ module.exports = ({
 
   app.get('/', (req, res, next) => {
     res.locals.reducers = [ 'user', 'url', ...reducers ];
-    next();
-  });
-
-  app.get('/', (req, res, next) => {
-    res.store = createStore(combineReducers(allReducers), {
-      user: {
-        id: req.user.id,
-        name: req.user.get('name')
-      },
-      list: {
-        schema
-      }
-    });
-    res.locals.store = res.store;
+    res.store.dispatch(actions.setSchema(schema));
     next();
   });
 

--- a/lib/reducers/list.js
+++ b/lib/reducers/list.js
@@ -10,6 +10,11 @@ module.exports = (state = INITIAL_STATE, action) => {
         ...state,
         data: action.data
       };
+    case 'SET_SCHEMA':
+      return {
+        ...state,
+        schema: action.schema
+      };
   }
   return state;
 };

--- a/ui/index.js
+++ b/ui/index.js
@@ -7,6 +7,9 @@ const { MemoryStore } = require('express-session');
 const session = require('@lennym/redis-session');
 const { assets } = require('govuk-react-components');
 
+const { combineReducers, createStore } = require('redux');
+const allReducers = require('../lib/reducers');
+
 const sendResponse = require('../lib/send-response');
 const errorHandler = require('../lib/error-handler');
 
@@ -75,6 +78,17 @@ module.exports = settings => {
 
   app.use((req, res, next) => {
     res.locals.user = req.user;
+    next();
+  });
+
+  app.use((req, res, next) => {
+    res.store = createStore(combineReducers(allReducers), {
+      user: {
+        id: req.user.id,
+        name: req.user.get('name')
+      }
+    });
+    res.locals.store = res.store;
     next();
   });
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -33,7 +33,10 @@ module.exports = settings => {
 
   app.set('trust proxy', true);
   app.set('view engine', 'jsx');
-  app.set('views', path.resolve(__dirname, './views'));
+  app.set('views', [
+    settings.views,
+    path.resolve(__dirname, '../pages/common/views')
+  ]);
 
   app.engine('jsx', expressViews.createEngine({
     transformViews: false


### PR DESCRIPTION
This makes references to the error template a lot simpler since it can be used directly from the `common` directory.

Additionally it allows the error page templates (and any other future non-page-specific templates) to be overridden in an implementation.

This needs to branch from the top of #12 so merge that first - or don't, I'm not your dad.