### PR TITLE
Fix props for search component

### DIFF
--- a/pages/common/views/containers/search.jsx
+++ b/pages/common/views/containers/search.jsx
@@ -8,5 +8,5 @@ const mapStateToProps = ({ filters }) => ({
 
 module.exports = connect(
   mapStateToProps,
-  { setFilter }
+  { onChange: value => setFilter('*', value) }
 )(Search);


### PR DESCRIPTION
An `onChange` prop was not being passed to the component. Pass `setFilter` with a global filter as an `onChange` prop.