### PR TITLE
Fix licenceHolder extraction from establishment data

### DIFF
--- a/lib/reducers/establishment.js
+++ b/lib/reducers/establishment.js
@@ -4,8 +4,10 @@ const establishment = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case 'SET_ESTABLISHMENT':
       let licenceHolder;
-      if (Array.isArray(action.establishment.roles)) {
-        licenceHolder = action.establishment.roles.find(r => r.type === 'elh');
+      if (action.establishment.pelh) {
+        licenceHolder = action.establishment.pelh;
+      } else if (Array.isArray(action.establishment.roles)) {
+        licenceHolder = action.establishment.roles.find(r => r.type === 'pelh' || r.type === 'elh');
       }
       return { ...action.establishment, licenceHolder };
   }


### PR DESCRIPTION
Handles the fact that the API has changed to provide potentially multiple ways to access the EPL holder depending on the data state.

Make it backwards compatible for now, with a view to removing the roles-based access and multiple possible role types in future.