### PR TITLE
Simplify PEL holder code

### DIFF
--- a/lib/reducers/establishment.js
+++ b/lib/reducers/establishment.js
@@ -3,13 +3,7 @@ const INITIAL_STATE = {};
 const establishment = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case 'SET_ESTABLISHMENT':
-      let licenceHolder;
-      if (action.establishment.pelh) {
-        licenceHolder = action.establishment.pelh;
-      } else if (Array.isArray(action.establishment.roles)) {
-        licenceHolder = action.establishment.roles.find(r => r.type === 'pelh' || r.type === 'elh');
-      }
-      return { ...action.establishment, licenceHolder };
+      return { ...action.establishment };
   }
   return state;
 };

--- a/pages/establishment/views/index.jsx
+++ b/pages/establishment/views/index.jsx
@@ -6,12 +6,7 @@ const Index = ({
   establishment: {
     name,
     licenceNumber,
-    licenceHolder: {
-      profile: {
-        id,
-        name: elhName
-      }
-    }
+    pelh
   },
   url,
   ...props
@@ -36,7 +31,7 @@ const Index = ({
             <dd>{ licenceNumber }</dd>
 
             <dt>Licence holder</dt>
-            <dd><a href={`${url}/profile/${id}`}>{ elhName }</a></dd>
+            <dd><a href={`${url}/profile/${pelh.id}`}>{ pelh.name }</a></dd>
           </dl>
         </aside>
       </div>


### PR DESCRIPTION
This comes directly as a property on the API response now, so there's no need to extract it in the reducer.