### PR TITLE
Bugfix - AS-361

### DIFF
--- a/pages/people/views/index.jsx
+++ b/pages/people/views/index.jsx
@@ -28,7 +28,7 @@ const licenceTypes = profile => {
 
 export const formatters = {
   name: {
-    format: (name, person) => <a href={`/profile/${person.id}`}>{ name }</a>
+    format: (name, person) => <a href={`profile/${person.id}`}>{ name }</a>
   },
   roles: {
     format: data => joinAcronyms(data)


### PR DESCRIPTION
* Amended formatter for profile link on people page. Use relative link to prevent losing the beginning of the URL