### PR TITLE
Clean up filter/sort accessors

### DIFF
--- a/lib/reducers/filters.js
+++ b/lib/reducers/filters.js
@@ -2,11 +2,12 @@ const {
   isEmpty,
   chain,
   some,
-  result,
   pickBy,
   pick,
   every
 } = require('lodash');
+
+const { getValue } = require('../utils');
 
 const flattenNestedCols = ({ row, schema, col }) => {
   if (isEmpty(schema)) {
@@ -14,7 +15,7 @@ const flattenNestedCols = ({ row, schema, col }) => {
   }
   const values = chain(schema)
     .pickBy((s, k) => col === '*' ? s.show : col === k)
-    .mapValues((value, key) => result({ ...row, ...value }, 'accessor', row[key]))
+    .mapValues((value, key) => getValue(row, key, value))
     .value();
   return values;
 };

--- a/lib/reducers/sort.js
+++ b/lib/reducers/sort.js
@@ -1,4 +1,5 @@
-const { orderBy, result } = require('lodash');
+const { orderBy } = require('lodash');
+const { getValue } = require('../utils');
 
 const INITIAL_STATE = {
   column: '',
@@ -20,8 +21,7 @@ const sortReducer = (state = INITIAL_STATE, action) => {
 
 const getSortedData = ({ data, schema, sort: { ascending, column } }) => {
   if (column) {
-    return orderBy(data, item =>
-      result({ ...item, ...schema[column] }, 'accessor', item[column])
+    return orderBy(data, row => getValue(row, column, schema[column])
       , ascending ? 'asc' : 'desc');
   }
   return data;

--- a/lib/reducers/sort.js
+++ b/lib/reducers/sort.js
@@ -21,8 +21,8 @@ const sortReducer = (state = INITIAL_STATE, action) => {
 
 const getSortedData = ({ data, schema, sort: { ascending, column } }) => {
   if (column) {
-    return orderBy(data, row => getValue(row, column, schema[column])
-      , ascending ? 'asc' : 'desc');
+    const direction = ascending ? 'asc' : 'desc';
+    return orderBy(data, row => getValue(row, column, schema[column]), direction);
   }
   return data;
 };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash');
+
 const toTitleCase = str =>
   str.replace(/\w\S*/g, txt => `${txt.charAt(0).toUpperCase()}${txt.substr(1)}`);
 
@@ -11,7 +13,16 @@ const getTitle = (key, options = {}) => {
   return toTitleCase(key);
 };
 
+const getValue = (row, key, schema = {}) => {
+  const accessor = schema.accessor || key;
+  if (typeof accessor === 'function') {
+    return accessor(row);
+  }
+  return get(row, accessor);
+};
+
 module.exports = {
   toTitleCase,
-  getTitle
+  getTitle,
+  getValue
 };

--- a/test/unit/fixtures/schema.js
+++ b/test/unit/fixtures/schema.js
@@ -19,9 +19,7 @@ export default {
   },
   car: {
     show: true,
-    accessor() {
-      return get(this, 'car.year');
-    }
+    accessor: 'car.year'
   },
   animals: {
     show: true

--- a/test/unit/reducers/filters.spec.js
+++ b/test/unit/reducers/filters.spec.js
@@ -202,8 +202,8 @@ describe('rootReducer', () => {
         withContacts[3].contacts[2].name = 'Chosen Name';
         const schema = merge({}, state.schema, {
           contacts: {
-            accessor() {
-              return this.contacts.map(c => c.name);
+            accessor(row) {
+              return row.contacts.map(c => c.name);
             }
           }
         });


### PR DESCRIPTION
Allows the use of both string and function based accessors for sorting and filtering.

Abstracts a `getValue` function into utils to allow re-use in different contexts without putting too much logic in different places.