### PR TITLE
Allow dynamic content in Snippet component

### DIFF
--- a/pages/common/views/components/snippet.jsx
+++ b/pages/common/views/components/snippet.jsx
@@ -1,14 +1,16 @@
 import { get } from 'lodash';
 import React, { Fragment } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { render } from 'mustache';
 
-const Snippet = ({ content, children }) => (
-  <ReactMarkdown
-    source={get(content, children)}
+const Snippet = ({ content, children, ...props }) => {
+  const source = render(get(content, children), props);
+  return <ReactMarkdown
+    source={source}
     renderers={{ root: Fragment }}
     allowNode={(node, index, parent) => parent.type !== 'root'}
     unwrapDisallowed={true}
-  />
-);
+  />;
+};
 
 export default Snippet;


### PR DESCRIPTION
This allows snippets to be defined with dynamic content declared using mustache syntax, which is then resolved by any props passed into the component.

Initial use case: project table has a warning flag `Less than <n> months remaining`.