### PR TITLE
Fix error page scripts and status code

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,5 +1,6 @@
 module.exports = () => {
   return (error, req, res, next) => {
+    res.status(500);
     if (error.status) {
       res.status(error.status);
     }

--- a/pages/common/views/error.jsx
+++ b/pages/common/views/error.jsx
@@ -6,6 +6,7 @@ class Index extends React.Component {
     return (
       <App
         {...this.props}
+        scripts={[]}
       >
         <h1 className="heading-large">{this.props.error.message}</h1>
         <pre>


### PR DESCRIPTION
If an error was thrown in a page then it still injects scripts, which removes the error on the client, and replaces it with the page components with no data.

Additionally ensure a 500 is sent by default for errors. Currently non-specifically coded errors wtill serve 200.