### PR TITLE
Optimise api calls

### DIFF
--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -33,17 +33,9 @@ module.exports = ({ content } = {}) => {
   });
 
   app.get('/', (req, res, next) => {
-    req.api(`/establishment/${req.establishment}`)
-      .then(response => {
-        res.establishment = response.json.data;
-      })
-      .then(() => next())
-      .catch(next);
-  });
-
-  app.get('/', (req, res, next) => {
     req.api(`/establishment/${req.establishment}/profiles`)
       .then(response => {
+        res.establishment = response.json.meta.establishment;
         res.data = response.json.data.map(profile => {
           const roles = profile.roles.map(r => r.type.toUpperCase());
           if (profile.pil) {

--- a/pages/places/index.js
+++ b/pages/places/index.js
@@ -42,17 +42,9 @@ module.exports = ({ content } = {}) => {
   });
 
   app.get('/', (req, res, next) => {
-    req.api(`/establishment/${req.establishment}`)
-      .then(response => {
-        res.establishment = response.json.data;
-      })
-      .then(() => next())
-      .catch(next);
-  });
-
-  app.get('/', (req, res, next) => {
     req.api(`/establishment/${req.establishment}/places`)
       .then(response => {
+        res.establishment = response.json.meta.establishment;
         res.data = response.json.data;
       })
       .then(() => next())

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -16,20 +16,12 @@ module.exports = ({ content } = {}) => {
   app.get('/', (req, res, next) => {
     req.api(`/establishment/${req.establishment}/profile/${req.profile}`)
       .then(response => {
+        res.establishment = response.json.meta.establishment;
         if (response.json.data) {
           res.data = response.json.data;
         } else {
           throw new Error('Profile not found');
         }
-      })
-      .then(() => next())
-      .catch(next);
-  });
-
-  app.get('/', (req, res, next) => {
-    req.api(`/establishment/${req.establishment}`)
-      .then(response => {
-        res.establishment = response.json.data;
       })
       .then(() => next())
       .catch(next);

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -35,17 +35,9 @@ module.exports = ({ content } = {}) => {
   });
 
   app.get('/', (req, res, next) => {
-    req.api(`/establishment/${req.establishment}`)
-      .then(response => {
-        res.establishment = response.json.data;
-      })
-      .then(() => next())
-      .catch(next);
-  });
-
-  app.get('/', (req, res, next) => {
     req.api(`/establishment/${req.establishment}/projects`)
       .then(response => {
+        res.establishment = response.json.meta.establishment;
         res.data = response.json.data;
       })
       .then(() => next())


### PR DESCRIPTION
The data we require from the establishment to render pages is included in the meta.establishment property of the main API response so there is no need to make two API calls per page when one will suffice.

~Extends #40~