### PR TITLE
Skip page routers for non-matching page paths

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -1,6 +1,7 @@
-const { merge } = require('lodash');
+const { every } = require('lodash');
 const path = require('path');
 const express = require('express');
+const match = require('minimatch');
 const persistQuery = require('./middleware/persist-query');
 const actions = require('./actions');
 
@@ -13,15 +14,24 @@ module.exports = ({
 }) => {
   const app = express.Router();
 
+  const allowedSubPaths = ['/', '/assets/*', '/edit', '/delete'];
+
+  app.use((req, res, next) => {
+    if (every(allowedSubPaths, p => !match(req.path, p))) {
+      return next('router');
+    }
+    next();
+  });
+
   app.use('/assets', express.static(path.resolve(root, './dist')));
 
-  app.get('/', (req, res, next) => {
+  app.use((req, res, next) => {
     res.locals.reducers = [ 'user', 'url', 'content', ...reducers ];
     res.store.dispatch(actions.setSchema(schema));
     next();
   });
 
-  app.get('/', (req, res, next) => {
+  app.use((req, res, next) => {
     const url = req.baseUrl === '/'
       ? ''
       : req.baseUrl;
@@ -30,15 +40,14 @@ module.exports = ({
     next();
   });
 
-  app.get('/', (req, res, next) => {
-    const content = merge({}, req.appContent, pageContent);
-    res.store.dispatch(actions.setContent(content));
+  app.use((req, res, next) => {
+    res.store.dispatch(actions.setContent(pageContent));
     next();
   });
 
-  app.get('/', persistQuery());
+  app.use(persistQuery());
 
-  app.get('/', (req, res, next) => {
+  app.use((req, res, next) => {
     res.template = path.resolve(root, 'views/index');
     next();
   });

--- a/lib/reducers/content.js
+++ b/lib/reducers/content.js
@@ -1,11 +1,10 @@
 const INITIAL_STATE = {};
+const { merge } = require('lodash');
 
 const content = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case 'SET_CONTENT':
-      return {
-        ...action.content
-      };
+      return merge({}, state, { ...action.content });
   }
   return state;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1835,9 +1835,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "govuk_frontend_toolkit": "^7.4.1",
     "keycloak-connect": "^3.4.3",
     "lodash": "^4.17.5",
+    "minimatch": "^3.0.4",
     "moment": "^2.22.2",
     "morgan": "^1.9.0",
     "mustache": "^2.3.0",

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,6 +1,5 @@
 require('../lib/register');
 
-const { merge } = require('lodash');
 const express = require('express');
 const path = require('path');
 const expressViews = require('express-react-views');
@@ -10,6 +9,7 @@ const { assets } = require('govuk-react-components');
 
 const { combineReducers, createStore } = require('redux');
 const allReducers = require('../lib/reducers');
+const actions = require('../lib/actions');
 
 const sendResponse = require('../lib/send-response');
 const errorHandler = require('../lib/error-handler');
@@ -80,11 +80,6 @@ module.exports = settings => {
   }
 
   app.use((req, res, next) => {
-    req.appContent = merge({}, commonContent, settings.content || {});
-    next();
-  });
-
-  app.use((req, res, next) => {
     res.locals.user = req.user;
     next();
   });
@@ -97,6 +92,12 @@ module.exports = settings => {
       }
     });
     res.locals.store = res.store;
+    next();
+  });
+
+  app.use((req, res, next) => {
+    res.store.dispatch(actions.setContent(commonContent));
+    res.store.dispatch(actions.setContent(settings.content));
     next();
   });
 


### PR DESCRIPTION
A page router should only catch an exact match for its url (or a whitelist of subpaths), and not other - more specific - urls that sit underneath it.

Check the path at the opening of the page router and ensure it is not a more specific url, and if so then skip the router completely.