### PR TITLE
Include PPLH in roles for people directory

### DIFF
--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -49,6 +49,9 @@ module.exports = ({ content } = {}) => {
           if (profile.pil) {
             roles.push('PILH');
           }
+          if (profile.projects && profile.projects.length) {
+            roles.push('PPLH');
+          }
           return {
             ...profile,
             roles


### PR DESCRIPTION
If a person is a licence holder for a PPL then show it as one of their roles in the people directory.