### PR TITLE
Throw better error for undefined snippets

### DIFF
--- a/pages/common/views/components/snippet.jsx
+++ b/pages/common/views/components/snippet.jsx
@@ -4,7 +4,11 @@ import ReactMarkdown from 'react-markdown';
 import { render } from 'mustache';
 
 const Snippet = ({ content, children, ...props }) => {
-  const source = render(get(content, children), props);
+  const str = get(content, children);
+  if (str === undefined) {
+    throw new Error(`Could not locate content snippet: ${children}`);
+  }
+  const source = render(str, props);
   return <ReactMarkdown
     source={source}
     renderers={{ root: Fragment }}


### PR DESCRIPTION
If a snippet key doesn't resolve then at the moment mustache throws an error complaining about trying to render undefined. Instead throw an error that explains what's actually going on.