### PR TITLE
Add test directories to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+pages/**/tests


### PR DESCRIPTION
Where a page has defined inline functional tests ensure that they are not published to npm.