### PR TITLE
Set locals as static data

### DIFF
--- a/lib/middleware/breadcrumbs.js
+++ b/lib/middleware/breadcrumbs.js
@@ -6,11 +6,11 @@ module.exports = crumbs => {
   router.get('/', (req, res, next) => {
     res.locals.crumbs = crumbs && crumbs.map(c => {
       if (typeof c === 'string') {
-        return render(c, res.store.getState());
+        return render(c, res.locals);
       }
       return {
-        label: render(c.label, res.store.getState()),
-        href: render(c.href, res.store.getState())
+        label: render(c.label, res.locals),
+        href: render(c.href, res.locals)
       };
     });
     next();

--- a/ui/index.js
+++ b/ui/index.js
@@ -87,13 +87,7 @@ module.exports = settings => {
   });
 
   app.use(router);
-  /*
-  csv && app.use(generateCsv());
-  if (pdf) {
-    app.use(pdfRenderer(pdf));
-    app.use(generatePdf());
-  }
-*/
+
   app.use(sendResponse(settings));
   app.use(errorHandler());
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,15 +1,12 @@
 require('../lib/register');
 
+const { merge } = require('lodash');
 const express = require('express');
 const path = require('path');
 const expressViews = require('express-react-views');
 const { MemoryStore } = require('express-session');
 const session = require('@lennym/redis-session');
 const { assets } = require('govuk-react-components');
-
-const { combineReducers, createStore } = require('redux');
-const allReducers = require('../lib/reducers');
-const actions = require('../lib/actions');
 
 const sendResponse = require('../lib/send-response');
 const errorHandler = require('../lib/error-handler');
@@ -80,24 +77,12 @@ module.exports = settings => {
   }
 
   app.use((req, res, next) => {
-    res.locals.user = req.user;
-    next();
-  });
-
-  app.use((req, res, next) => {
-    res.store = createStore(combineReducers(allReducers), {
-      user: {
-        id: req.user.id,
-        name: req.user.get('name')
-      }
-    });
-    res.locals.store = res.store;
-    next();
-  });
-
-  app.use((req, res, next) => {
-    res.store.dispatch(actions.setContent(commonContent));
-    res.store.dispatch(actions.setContent(settings.content));
+    res.locals.user = {
+      id: req.user.id,
+      name: req.user.get('name')
+    };
+    res.locals.static = res.locals.static || {};
+    res.locals.static.content = merge({}, commonContent, settings.content);
     next();
   });
 


### PR DESCRIPTION
Rather than pushing all of the data we ever use into a redux store, which forces us to expose actions and reducers for data that won't ever change on the client, instead keep all of the locals as locals, and then take the subset which is needed to be used in the client and pass to a redux store.