### PR TITLE
Allow @asl prefixed node modules to be babel-ed

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = dirs => {
       rules: [
         {
           test: /\.jsx?/,
-          exclude: /node_modules/,
+          exclude: path => path.match(/node_modules/) && !path.match(/node_modules\/@asl/),
           loader: 'babel-loader'
         }
       ]


### PR DESCRIPTION
We need to exlude @asl modules from the exclusion list for babel-ing in webpack so that jsx will be properly parsed.