### PR TITLE
Use customisable layout with built-in default

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["env", "react"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,12 +1,16 @@
-module.exports = () => {
+const ErrorComponent = require('../ui/views/error');
+
+module.exports = settings => {
   return (error, req, res, next) => {
-    res.status(500);
-    if (error.status) {
-      res.status(error.status);
-    }
+    error.status = error.status || 500;
+    res.status(error.status);
     if (req.log) {
       req.log('error', error);
     }
-    res.render('error', { error });
+    res.render(res.layout || settings.layout || 'layout', {
+      Component: ErrorComponent.default || ErrorComponent,
+      scripts: [],
+      error
+    });
   };
 };

--- a/lib/send-response.js
+++ b/lib/send-response.js
@@ -1,6 +1,8 @@
 module.exports = settings => (req, res, next) => {
   if (res.template) {
-    return res.render(res.template);
+    return res.render(res.layout || settings.layout || 'layout', {
+      Component: res.template
+    });
   } else {
     const err = new Error('Not found');
     err.status = 404;

--- a/ui/index.js
+++ b/ui/index.js
@@ -35,7 +35,8 @@ module.exports = settings => {
   app.set('trust proxy', true);
   app.set('view engine', 'jsx');
   app.set('views', [
-    settings.views
+    settings.views,
+    path.resolve(__dirname, './views')
   ]);
 
   app.engine('jsx', expressViews.createEngine({
@@ -72,10 +73,12 @@ module.exports = settings => {
   }
 
   app.use((req, res, next) => {
-    res.locals.user = {
-      id: req.user.id,
-      name: req.user.get('name')
-    };
+    if (req.user) {
+      res.locals.user = {
+        id: req.user.id,
+        name: req.user.get('name')
+      };
+    }
     res.locals.static = res.locals.static || {};
     res.locals.static.content = merge({}, res.locals.static.content, settings.content);
     next();
@@ -84,7 +87,7 @@ module.exports = settings => {
   app.use(router);
 
   app.use(sendResponse(settings));
-  app.use(errorHandler());
+  app.use(errorHandler(settings));
 
   const _app = (...args) => app(...args);
 

--- a/ui/views/error.jsx
+++ b/ui/views/error.jsx
@@ -1,0 +1,8 @@
+import React, { Fragment } from 'react';
+
+export default ({ error }) => <Fragment>
+  <h1 className="heading-xlarge">{ error.message }</h1>
+  {
+    error.status > 499 && <pre>{ error.stack }</pre>
+  }
+</Fragment>;

--- a/ui/views/layout.jsx
+++ b/ui/views/layout.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import GovUK from 'govuk-react-components/components/layout';
+
+const Layout = ({
+  Component,
+  ...props
+}) => {
+  return (
+    <GovUK
+      {...props}
+    >
+      <main className="main" id="content">
+        <div className="grid-row">
+          <div className="column-full">
+            <div id="page-component">
+              <Component {...props} />
+            </div>
+          </div>
+        </div>
+      </main>
+    </GovUK>
+  );
+};
+
+module.exports = Layout;


### PR DESCRIPTION
This allows implementations to decouple from @asl/pages by including a standard layout and error template