### PR TITLE
Expose `param` method to implementations

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -92,6 +92,7 @@ module.exports = settings => {
   const _app = (...args) => app(...args);
 
   return Object.assign(_app, {
+    param: (...args) => router.param(...args),
     protect: (...args) => app.protect(...args),
     listen: (...args) => app.listen(...args),
     static: staticrouter,


### PR DESCRIPTION
Allows the use of `app.param()` calls for parsing url parameters in implementing projects.