### PR TITLE
Allow data urls to be used for images

### DIFF
--- a/lib/get-content-security-policy.js
+++ b/lib/get-content-security-policy.js
@@ -5,7 +5,7 @@ const getContentSecurityPolicy = config => {
   const directives = {
     defaultSrc: [`'none'`],
     styleSrc: [`'self'`],
-    imgSrc: [`'self'`],
+    imgSrc: [`'self' data:`],
     fontSrc: [`'self'`, 'data:'],
     scriptSrc: [`'self'`, (req, res) => `'nonce-${res.locals.static.nonce}'`]
   };


### PR DESCRIPTION
Adds to the content security policy default directives to allow data urls in CSS.