### PR TITLE
Add support for profile based user authentication

### DIFF
--- a/lib/auth/profile.js
+++ b/lib/auth/profile.js
@@ -1,0 +1,20 @@
+const api = require('../api');
+
+module.exports = (endpoint) => {
+
+  if (!endpoint) {
+    return () => Promise.resolve(null);
+  }
+
+  const request = api(endpoint);
+
+  return token => {
+    const headers = {
+      Authorization: `bearer ${token}`
+    };
+    return request(`/me`, { headers })
+      .then(response => response.json.data)
+      .catch(() => null);
+  };
+
+};

--- a/ui/index.js
+++ b/ui/index.js
@@ -86,12 +86,7 @@ module.exports = settings => {
   }));
 
   app.use((req, res, next) => {
-    if (req.user) {
-      res.locals.user = {
-        id: req.user.id,
-        name: req.user.get('name')
-      };
-    }
+    res.locals.user = req.user || {};
     res.locals.static = res.locals.static || {};
     set(res.locals, 'static.content', merge({}, res.locals.static.content, settings.content));
     set(res.locals, 'static.urls', merge({}, settings.urls));


### PR DESCRIPTION
Rather than loading data from the keycloak representation of the user, instead use the profile loaded from the database to get user data.