### PR TITLE
Fix profile caching bug

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -24,7 +24,7 @@ module.exports = settings => {
   const permissions = can(settings.permissions);
 
   router.use((req, res, next) => {
-    if (!req.session && !settings.bearerOnly) {
+    if (req.path !== '/logout' && !req.session && !settings.bearerOnly) {
       return next(new Error('No session'));
     }
     next();
@@ -36,7 +36,11 @@ module.exports = settings => {
     next(e);
   };
 
-  router.use(keycloak.middleware());
+  router.use('/logout', (req, res) => {
+    res.redirect('/keycloak/logout');
+  });
+
+  router.use(keycloak.middleware({ logout: '/keycloak/logout' }));
   router.use(keycloak.protect());
   router.use((req, res, next) => {
     const user = {

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -39,12 +39,14 @@ module.exports = settings => {
   router.use(keycloak.middleware());
   router.use(keycloak.protect());
   router.use((req, res, next) => {
-    const user = req.kauth.grant.access_token;
-
-    getProfile(user.token, req.session)
+    const user = {
+      id: req.kauth.grant.access_token.content.sub,
+      token: req.kauth.grant.access_token.token
+    };
+    getProfile(user, req.session)
       .then(p => {
         req.user = {
-          id: user.content.sub,
+          id: user.id,
           profile: p,
           access_token: user.token,
           can: (task, params) => permissions(user.token, task, params)

--- a/lib/auth/profile.js
+++ b/lib/auth/profile.js
@@ -9,16 +9,16 @@ module.exports = (endpoint) => {
 
   const request = api(endpoint);
 
-  return (token, session) => {
+  return (user, session) => {
 
     return Promise.resolve()
       .then(() => {
-        if (!session.profile ||
-          (session.profile &&
-            moment().isAfter(moment(session.profile.expiresAt)))) {
+        if (session.profile && Date.now() < session.profile.expiresAt && session.profile.userId && session.profile.userId === user.id) {
+          return session.profile;
+        } else {
 
           const headers = {
-            Authorization: `bearer ${token}`
+            Authorization: `bearer ${user.token}`
           };
 
           return request(`/me`, { headers })
@@ -28,8 +28,6 @@ module.exports = (endpoint) => {
               return p;
             })
             .catch(() => null);
-        } else {
-          return session.profile;
         }
       })
       .then(profile => {

--- a/lib/auth/profile.js
+++ b/lib/auth/profile.js
@@ -9,26 +9,30 @@ module.exports = (endpoint) => {
 
   const request = api(endpoint);
 
-  return (user, session) => {
+  return (user, session = {}) => {
 
     return Promise.resolve()
       .then(() => {
-        if (session.profile && Date.now() < session.profile.expiresAt && session.profile.userId && session.profile.userId === user.id) {
-          return session.profile;
-        } else {
-
-          const headers = {
-            Authorization: `bearer ${user.token}`
-          };
-
-          return request(`/me`, { headers })
-            .then(response => {
-              const p = response.json.data;
-              p.expiresAt = moment.utc(moment().add(600, 'seconds')).valueOf();
-              return p;
-            })
-            .catch(() => null);
+        // check for cached session profile
+        if (session.profile) {
+          const fresh = Date.now() < session.profile.expiresAt;
+          const userId = session.profile.userId;
+          if (fresh && userId && userId === user.id) {
+            return session.profile;
+          }
         }
+
+        const headers = {
+          Authorization: `bearer ${user.token}`
+        };
+
+        return request(`/me`, { headers })
+          .then(response => {
+            const p = response.json.data;
+            p.expiresAt = moment.utc(moment().add(600, 'seconds')).valueOf();
+            return p;
+          })
+          .catch(() => null);
       })
       .then(profile => {
         session.profile = profile;

--- a/test/unit/profile/index.spec.js
+++ b/test/unit/profile/index.spec.js
@@ -50,11 +50,12 @@ describe('cache profile loading in service/auth', () => {
       profile: {
         firstName: 'Someone',
         lastName: 'Else',
+        userId: 'abc123',
         expiresAt: moment.utc(moment().add(60, 'seconds')).valueOf()
       }
     };
 
-    return profile(service.url)('token', session)
+    return profile(service.url)({ token: 'token', id: 'abc123' }, session)
       .then(() => {
         expect(service.stub.callCount).toEqual(0);
         expect(session).toHaveProperty('profile');
@@ -68,11 +69,31 @@ describe('cache profile loading in service/auth', () => {
       profile: {
         firstName: 'Someone',
         lastName: 'Else',
+        userId: 'abc123',
         expiresAt: moment.utc(moment().subtract(660, 'seconds')).valueOf()
       }
     };
 
-    return profile(service.url)('token', session)
+    return profile(service.url)({ token: 'token', id: 'abc123' }, session)
+      .then(() => {
+        expect(service.stub.callCount).toEqual(1);
+        expect(session).toHaveProperty('profile');
+        expect(session.profile.firstName).toEqual('First');
+        expect(session.profile.lastName).toEqual('Last');
+      });
+  });
+
+  it('should call profile api if session profile user id does not match logged in user', () => {
+    const session = {
+      profile: {
+        firstName: 'Someone',
+        lastName: 'Else',
+        userId: 'abc123',
+        expiresAt: moment.utc(moment().add(60, 'seconds')).valueOf()
+      }
+    };
+
+    return profile(service.url)({ token: 'token', id: 'def456' }, session)
       .then(() => {
         expect(service.stub.callCount).toEqual(1);
         expect(session).toHaveProperty('profile');

--- a/ui/index.js
+++ b/ui/index.js
@@ -58,6 +58,9 @@ module.exports = settings => {
 
   if (settings.session) {
     app.use(session(settings.session));
+    app.use('/logout', (req, res, next) => {
+      req.session.destroy(() => next());
+    });
   }
   if (settings.auth) {
     const keycloak = auth(Object.assign({ store: new MemoryStore() }, settings.auth));


### PR DESCRIPTION
Previous logout implementation didn't actually destroy the session, so the profile was left cached if logging in as a different user. Fix this twice by:

a) checking the user ids match when loading a cached profile
b) ensuring the session is destroyed when hitting `/logout`

Need to do a bit of a redirect dance with keycloak to get it to logout properly. It errors if hit with no session at all, so need the keycloak logout call to be on a separate request to the session destroy call.