### PR TITLE
Move the phase banner into asl-service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,9 +103,9 @@
       "dev": true
     },
     "@ukhomeoffice/frontend-toolkit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/frontend-toolkit/-/frontend-toolkit-2.0.0.tgz",
-      "integrity": "sha512-CA+PZfXkPUtGt3tVklqNiFuZvZFcZETmVB3e7qfRxd9/GcXVSvSGy9qCtxMIYFu+tcb70TEqTGz6gUCAk2HvaQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/frontend-toolkit/-/frontend-toolkit-2.1.1.tgz",
+      "integrity": "sha512-e14ZgKDvVj44F8NWOhd/5W7Szh/Cer53A8+DcHaL1mVPinKfu8bk+G/Ql9X65ZWIXe4p+DyOadYehcuBW5Q9eg==",
       "requires": {
         "govuk-elements-sass": "^3.1.2",
         "govuk-frontend": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-service#readme",
   "dependencies": {
     "@lennym/redis-session": "^1.0.4",
-    "@ukhomeoffice/frontend-toolkit": "^2.0.0",
+    "@ukhomeoffice/frontend-toolkit": "^2.1.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",

--- a/ui/components/home-office.jsx
+++ b/ui/components/home-office.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import PhaseBanner from './phase-banner';
 
 class HomeOffice extends React.Component {
 
@@ -21,6 +22,10 @@ class HomeOffice extends React.Component {
         </head>
 
         <body>
+
+          {
+            this.props.phaseBanner && <PhaseBanner {...this.props.phaseBanner} />
+          }
 
           <header role="banner" className={this.props.propositionHeader ? 'with-proposition' : ''}>
             <div className="font-ui wrapper-header">
@@ -67,6 +72,27 @@ class HomeOffice extends React.Component {
           </footer>
 
           <div id="global-app-error" className="app-error hidden"></div>
+
+          {
+            this.props.phaseBanner && <script nonce={this.props.nonce} dangerouslySetInnerHTML={{__html: `
+
+              function checkHeight() {
+                const phaseBanner = document.getElementsByClassName('govuk-phase-banner')[0];
+                const footerHeight = document.getElementById('footer-withphase').offsetHeight || 50;
+
+                if (window.innerHeight + window.scrollY + footerHeight > document.body.clientHeight) {
+                  phaseBanner.style.display = 'none';
+                } else {
+                  phaseBanner.style.display = 'block';
+                }
+              }
+
+              document.addEventListener("DOMContentLoaded", function(event) {
+                window.addEventListener('scroll', checkHeight);
+              });
+
+            `}} />
+          }
 
           {
             this.props.scripts.map(file => (

--- a/ui/components/home-office.jsx
+++ b/ui/components/home-office.jsx
@@ -76,7 +76,7 @@ class HomeOffice extends React.Component {
           {
             this.props.phaseBanner && <script nonce={this.props.nonce} dangerouslySetInnerHTML={{__html: `
 
-              function checkHeight() {
+              function togglePhaseBanner() {
                 const phaseBanner = document.getElementsByClassName('govuk-phase-banner')[0];
                 const footerHeight = document.getElementById('footer-withphase').offsetHeight || 50;
 
@@ -87,8 +87,9 @@ class HomeOffice extends React.Component {
                 }
               }
 
-              document.addEventListener("DOMContentLoaded", function(event) {
-                window.addEventListener('scroll', checkHeight);
+              document.addEventListener('DOMContentLoaded', function(event) {
+                togglePhaseBanner();
+                window.addEventListener('scroll', togglePhaseBanner);
               });
 
             `}} />

--- a/ui/components/home-office.jsx
+++ b/ui/components/home-office.jsx
@@ -77,8 +77,8 @@ class HomeOffice extends React.Component {
             this.props.phaseBanner && <script nonce={this.props.nonce} dangerouslySetInnerHTML={{__html: `
 
               function togglePhaseBanner() {
-                const phaseBanner = document.getElementsByClassName('govuk-phase-banner')[0];
-                const footerHeight = document.getElementById('footer-withphase').offsetHeight || 50;
+                const phaseBanner = document.querySelector('.govuk-phase-banner');
+                const footerHeight = document.querySelector('#footer-withphase').offsetHeight || 50;
 
                 if (window.innerHeight + window.scrollY + footerHeight > document.body.clientHeight) {
                   phaseBanner.style.display = 'none';

--- a/ui/components/phase-banner.jsx
+++ b/ui/components/phase-banner.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class PhaseBanner extends React.Component {
+
+  renderContent() {
+    if (this.props.content) {
+      return this.props.content;
+    } else if (this.props.feedbackUrl) {
+      return <span className="govuk-phase-banner__text">
+        This is a new service – your <a href={this.props.feedbackUrl} className="govuk-link">feedback</a> will help us to improve it.
+      </span>;
+    }
+  }
+
+  render() {
+    return <div className="govuk-phase-banner">
+      <div className="govuk-width-container">
+        <p className="govuk-phase-banner__content">
+          <strong className="govuk-tag govuk-phase-banner__content__tag">{this.props.phase}</strong>
+          { this.renderContent() }
+        </p>
+      </div>
+    </div>;
+  }
+
+}
+
+PhaseBanner.defaultProps = {
+  phase: 'alpha'
+};
+
+PhaseBanner.propTypes = {
+  phase: PropTypes.oneOf(['prototype', 'alpha', 'beta']),
+  feedbackUrl: PropTypes.string
+};
+
+export default PhaseBanner;


### PR DESCRIPTION
We have moved the phase-banner component from asl/pages to asl/service and added some simple javascript to hide the banner when you scroll to the bottom of the page.

Because PhaseBanner is outside of the `page-component` div, javascript in `phase-banner.jsx` does not get bundled for the client side, so we're adding it to the bottom of the body in the layout.