### PR TITLE
Support permissions tasks that are not defined by an establishment

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -49,12 +49,17 @@ module.exports = settings => {
     };
     getProfile(user, req.session)
       .then(p => {
+        const allowed = []
+          .concat(p.allowedActions.global)
+          .concat(p.allowedActions[req.establishment])
+          .filter(Boolean);
+
         req.user = {
           id: user.id,
           profile: p,
           access_token: user.token,
           can: (task = '', params) => permissions(user.token, task, params).then(res => res || true).catch(() => false),
-          isAllowed: task => p.allowedActions[req.establishment].includes(task)
+          isAllowed: task => allowed.includes(task)
         };
       })
       .then(() => next())


### PR DESCRIPTION
In particular, an internal user looking for `establishment.list` permissions will - by definition - not be within the context of any one establishment, and so a "global" list of allowed tasks should be added to the per-establishment list in order to determine if a user is able to perform that task.