### PR TITLE
Handle null profile case for loading allowed actions

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -1,5 +1,6 @@
 const Keycloak = require('keycloak-connect');
 const {Router} = require('express');
+const { get } = require('lodash');
 
 const can = require('./can');
 const Profile = require('./profile');
@@ -50,9 +51,8 @@ module.exports = settings => {
     getProfile(user, req.session)
       .then(p => {
         const allowed = []
-          .concat(p.allowedActions.global)
-          .concat(p.allowedActions[req.establishment])
-          .filter(Boolean);
+          .concat(get(p, 'allowedActions.global', []))
+          .concat(get(p, `allowedActions.${req.establishment}`, []));
 
         req.user = {
           id: user.id,


### PR DESCRIPTION
Not all services will load a user profile as part of the auth pipeline, so we can't assume a profile exists when applying the authentication middlewares.