### PR TITLE
Remove `isAllowed` function from user object

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -1,6 +1,5 @@
 const Keycloak = require('keycloak-connect');
 const {Router} = require('express');
-const { get } = require('lodash');
 
 const can = require('./can');
 const Profile = require('./profile');
@@ -50,16 +49,11 @@ module.exports = settings => {
     };
     getProfile(user, req.session)
       .then(p => {
-        const allowed = []
-          .concat(get(p, 'allowedActions.global', []))
-          .concat(get(p, `allowedActions.${req.establishment}`, []));
-
         req.user = {
           id: user.id,
           profile: p,
           access_token: user.token,
-          can: (task = '', params) => permissions(user.token, task, params).then(res => res || true).catch(() => false),
-          isAllowed: task => allowed.includes(task)
+          can: (task = '', params) => permissions(user.token, task, params).then(() => true).catch(() => false)
         };
       })
       .then(() => next())


### PR DESCRIPTION
There are currently two functions being attached to the user object which perform the same action in two different ways.

Remove the `isAllowed` function (which is currently buggy) in favour of standardising on `can` and having a single source of permissions truth for server actions.