### PR TITLE
Add `allowedActions` method to user

### DIFF
--- a/lib/auth/can.js
+++ b/lib/auth/can.js
@@ -12,7 +12,7 @@ module.exports = (endpoint) => {
 
   const request = api(endpoint);
 
-  return (token, task, query) => {
+  return (token, task = '', query) => {
     const headers = {
       Authorization: `bearer ${token}`
     };

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -53,9 +53,12 @@ module.exports = settings => {
           id: user.id,
           profile: p,
           access_token: user.token,
-          can: (task = '', params) => permissions(user.token, task, params)
-            .then(response => task ? true : response)
-            .catch(() => false)
+          can: (task, params) => {
+            return permissions(user.token, task, params).then(() => true).catch(() => false);
+          },
+          allowedActions: () => {
+            return permissions(user.token).then(response => response.json);
+          }
         };
       })
       .then(() => next())


### PR DESCRIPTION
Instead of overloading the `can` function to do different things in different contexts, instead create a separate method for getting the actions allowed by the logged in user.