### PR TITLE
Expose details of underlying auth data on req.user

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -60,6 +60,10 @@ module.exports = settings => {
             return permissions(user.token).then(response => response.json);
           }
         };
+
+        Object.defineProperty(req.user, '_auth', {
+          value: req.kauth.grant.access_token.content
+        });
       })
       .then(() => next())
       .catch(next);


### PR DESCRIPTION
Uses `defineProperty` to ensure that the property is only visible if you explicitly go looking for it (i.e. non-enumerable), and can't be accidentally modified.