### PR TITLE
Allow custom error templates

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -7,8 +7,9 @@ module.exports = settings => {
     if (req.log) {
       req.log('error', error);
     }
+    const Component = error.template || ErrorComponent;
     res.render(res.layout || settings.layout || 'layout', {
-      Component: ErrorComponent.default || ErrorComponent,
+      Component: Component.default || Component,
       scripts: [],
       error
     });


### PR DESCRIPTION
This means that certain errors can be more nicely handled by adding a custom template, with messages relevant to the error type, and a useful call to action.