### PR TITLE
Refactor sending responses

### DIFF
--- a/lib/send-response.js
+++ b/lib/send-response.js
@@ -1,28 +1,30 @@
 const { omit } = require('lodash');
 
 module.exports = settings => (req, res, next) => {
+  res.sendResponse = () => {
+    if (!res.template) {
+      const err = new Error('Not found');
+      err.status = 404;
+      throw err;
+    }
 
-  if (!res.template) {
-    const err = new Error('Not found');
-    err.status = 404;
-    return next(err);
-  }
-
-  if (req.accepts('html')) {
-    return res.render(res.layout || settings.layout || 'layout', {
-      Component: res.template
-    });
-  } else if (req.accepts('application/json')) {
-    res.set({
-      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
-      Pragma: 'no-cache',
-      Expires: 0,
-      'Surrogate-Control': 'no-store'
-    });
-    res.json(omit(res.locals, ['static', 'cache', '_locals', 'settings']));
-  } else {
-    const err = new Error('Not acceptable');
-    err.status = 406;
-    next(err);
-  }
+    if (req.accepts('html')) {
+      return res.render(res.layout || settings.layout || 'layout', {
+        Component: res.template
+      });
+    } else if (req.accepts('application/json')) {
+      res.set({
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        Pragma: 'no-cache',
+        Expires: 0,
+        'Surrogate-Control': 'no-store'
+      });
+      res.json(omit(res.locals, ['static', 'cache', '_locals', 'settings']));
+    } else {
+      const err = new Error('Not acceptable');
+      err.status = 406;
+      throw err;
+    }
+  };
+  next();
 };

--- a/ui/index.js
+++ b/ui/index.js
@@ -91,9 +91,15 @@ module.exports = settings => {
     next();
   });
 
+  app.use(sendResponse(settings));
+
   app.use(router);
 
-  app.use(sendResponse(settings));
+  // if the response has not yet been sent then send it
+  app.use((req, res) => {
+    res.sendResponse();
+  });
+
   app.use(errorHandler(settings));
 
   const _app = (...args) => app(...args);


### PR DESCRIPTION
Previously the request would have to traverse the entire router stack before it was sent, which causes problems with having to ensure that no subsequent middlewares or routers were able to modify the response.

Instead keep a single point of request termination, but allow for a request to be temrinated at any point in the router stack by providing a method by which any router can opt to send its response.