### PR TITLE
Allow messages for 4xx range errors

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -8,8 +8,9 @@ module.exports = settings => {
       req.log('error', error);
     }
 
-    if (!settings.verboseErrors) {
+    if (!settings.verboseErrors && error.status > 499) {
       error.message = 'Something went wrong';
+      error.stack = null;
     }
 
     if (req.accepts('html')) {

--- a/ui/views/error.jsx
+++ b/ui/views/error.jsx
@@ -3,6 +3,6 @@ import React, { Fragment } from 'react';
 export default ({ error }) => <Fragment>
   <h1 className="heading-xlarge">{ error.message }</h1>
   {
-    error.status > 499 && <pre>{ error.stack }</pre>
+    error.status > 499 && error.stack && <pre>{ error.stack }</pre>
   }
 </Fragment>;


### PR DESCRIPTION
4xx range errors have useful messages like "Unauthorised" and "Not found" that should not be suppressed.