### PR TITLE
Apply babel transforms to all js

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = dirs => {
     module: {
       rules: [
         {
-          test: /\.jsx/,
+          test: /\.js(x)?/,
           exclude: path => path.match(/node_modules/) && !path.match(/node_modules\/@asl/),
           loader: 'babel-loader'
         }


### PR DESCRIPTION
Include `.js` files that don't contain JSX but do need to be babel-ified for x-browser compatibility reasons.