### PR TITLE
Attempt to exclude all non-@asl modules from babel-loader

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -58,7 +58,16 @@ module.exports = dirs => {
       rules: [
         {
           test: /\.js(x)?/,
-          exclude: path => path.match(/node_modules/) && !path.match(/node_modules\/@asl/),
+          exclude: path => {
+            const parts = path.split('/');
+            const notASL = parts
+              // get the name of every immediate  child directory of node_modules in the path
+              .map((dir, i) => dir === 'node_modules' && parts[i + 1])
+              // are any of them not @asl?
+              .some(dir => dir !== '@asl');
+            // if any are *not* @asl then exclude from babel
+            return notASL;
+          },
           loader: 'babel-loader'
         }
       ]


### PR DESCRIPTION
There's a problem now that we converted babel to compile _all_ .js files and not just .jsx that now files in child dependecies of `@asl/*` modules are being compiled, which would be fine, but if one contains a `.babelrc` file then it can fail with missing presets.

This is an attempt to exclude all modules which are not themselves `@asl/*` modules, but which might sit within a subdirectory such as `./node_modules/@asl/pages/node_modules/not-asl`, which would then (incorrectly) match the previous criteria as it sits within a `node_modules/@asl` directory.