### PR TITLE
Add cache control middleware

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -5,11 +5,13 @@ const auth = require('../lib/auth');
 const normalise = require('../lib/settings');
 const logger = require('../lib/logger');
 const workflow = require('../lib/workflow');
+const cacheControl = require('../lib/middleware/cache-control');
 
 module.exports = settings => {
   settings = normalise(settings);
   const app = express();
 
+  app.use(cacheControl(settings));
   app.use(logger(settings));
 
   if (settings.auth) {

--- a/lib/middleware/cache-control.js
+++ b/lib/middleware/cache-control.js
@@ -1,0 +1,6 @@
+module.exports = () => (req, res, next) => {
+  res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.set('Pragma', 'no-cache');
+  res.set('Expires', 0);
+  next();
+};

--- a/ui/router.js
+++ b/ui/router.js
@@ -18,6 +18,7 @@ const normalise = require('../lib/settings');
 const logger = require('../lib/logger');
 const routeBuilder = require('../lib/middleware/route-builder');
 const notifications = require('../lib/middleware/notifications');
+const cacheControl = require('../lib/middleware/cache-control');
 
 module.exports = settings => {
 
@@ -51,6 +52,7 @@ module.exports = settings => {
 
   app.use('/ho', express.static(homeOffice.assets));
 
+  app.use(cacheControl(settings));
   app.use(logger(settings));
 
   if (settings.session) {


### PR DESCRIPTION
Prevents any responses containing data from being cached in a browser.

Allows static assets served by UI services to still be cached by default.