### PR TITLE
Optimise the webpack config for memory usage

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -71,7 +71,7 @@ module.exports = dirs => {
     optimization: {
       minimizer: [
         new TerserPlugin({
-          parallel: true,
+          parallel: false,
           cache: true
         })
       ],
@@ -80,7 +80,7 @@ module.exports = dirs => {
           commons: {
             name: 'common',
             chunks: 'initial',
-            minChunks: Object.keys(entry).length
+            minChunks: Math.ceil(Object.keys(entry).length / 2)
           }
         }
       }


### PR DESCRIPTION
Remove parallel execution of script minifying so that memory usage is capped at the usage of a single thread, and not 4x when threads are running in parallel.

Additionally reduce the threshold for scripts to be bundled in the common bundle.