### PR TITLE
Optimise babel register to reduce compilation on startup

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -1,6 +1,11 @@
 const babelrc = require('../.babelrc.json');
 
-require('@babel/register')({ ...babelrc,
+require('@babel/register')({
+  ...babelrc,
   ignore: [
-    p => p.match(/node_modules/) && !p.match(/@joefitter\/docx/) && !p.match(/@asl/)
-  ] });
+    // ignore files that are not .jsx unless they're in an @asl scoped dependency
+    p => !p.match(/.jsx/) && !p.match(/@asl/),
+    // ignore node modules that are not @asl owned dependencies
+    p => p.match(/node_modules/) && !(p.match(/@joefitter\/docx/) || p.match(/@asl/))
+  ]
+});


### PR DESCRIPTION
By excluding all non-asl, non-jsx files from babel-register we can greatly improve the time taken to start the app. Local testing yields a roughly 400% improvement in start-up speed (Before: ~30s, After: ~6s).