### PR TITLE
Log complete errors

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -5,7 +5,7 @@ module.exports = settings => {
     error.status = error.status || 500;
     res.status(error.status);
     if (req.log) {
-      req.log('error', error);
+      req.log('error', { ...error, message: error.message, stack: error.stack });
     }
 
     if (!settings.verboseErrors && error.status > 499) {


### PR DESCRIPTION
`message` and `stack` are non-enumerable properties of an error object, so don't get logged right now. That is not very useful.