### PR TITLE
Add healthcheck endpoints to services

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -11,6 +11,10 @@ module.exports = settings => {
   settings = normalise(settings);
   const app = express();
 
+  app.get('/healthcheck', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
   app.use(cacheControl(settings));
   app.use(logger(settings));
 

--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -1,0 +1,17 @@
+const fetch = require('r2');
+
+module.exports = settings => (req, res) => {
+  if (settings.api) {
+    return fetch(`${settings.api}/healthcheck`)
+      .then(response => {
+        if (response.status !== 200) {
+          res.status(500);
+          res.json({
+            status: 'failed',
+            message: `Could not connect to downstream API at ${settings.api}`
+          });
+        }
+      });
+  }
+  res.json({ status: 'ok' });
+};

--- a/ui/router.js
+++ b/ui/router.js
@@ -16,6 +16,7 @@ const auth = require('../lib/auth');
 const api = require('../lib/api');
 const normalise = require('../lib/settings');
 const logger = require('../lib/logger');
+const healthcheck = require('../lib/healthcheck');
 const routeBuilder = require('../lib/middleware/route-builder');
 const notifications = require('../lib/middleware/notifications');
 const cacheControl = require('../lib/middleware/cache-control');
@@ -43,6 +44,8 @@ module.exports = settings => {
   app.engine('jsx', expressViews.createEngine({
     transformViews: false
   }));
+
+  app.get('/healthcheck', healthcheck(settings));
 
   app.use(staticrouter);
 


### PR DESCRIPTION
Allows us to check if a service is up and running and responding to requests. Useful for monitoring, and potentially preventing some of the occasional race conditions in integration tests.