### PR TITLE
Refactor healthcheck to support liveness and readiness

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -5,15 +5,14 @@ const auth = require('../lib/auth');
 const normalise = require('../lib/settings');
 const logger = require('../lib/logger');
 const workflow = require('../lib/workflow');
+const healthcheck = require('../lib/healthcheck');
 const cacheControl = require('../lib/middleware/cache-control');
 
 module.exports = settings => {
   settings = normalise(settings);
   const app = express();
 
-  app.get('/healthcheck', (req, res) => {
-    res.json({ status: 'ok' });
-  });
+  app.use('/healthcheck', healthcheck());
 
   app.use(cacheControl(settings));
   app.use(logger(settings));

--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -15,6 +15,9 @@ module.exports = settings => {
           return { url, status: response.status };
         }
         return false;
+      })
+      .catch(() => {
+        return { url, status: null };
       });
   };
 

--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -15,8 +15,7 @@ module.exports = settings => {
         }
         return false;
       });
-
-  }
+  };
 
   router.get('/ready', (req, res) => {
     const services = [settings.api, settings.workflow];
@@ -35,7 +34,7 @@ module.exports = settings => {
       });
   });
 
-  router.get('*', (req, res) => {
+  router.get('/', (req, res) => {
     res.json({ status: 'ok' });
   });
 

--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -1,4 +1,5 @@
 const fetch = require('r2');
+const { get } = require('lodash');
 const { Router } = require('express');
 
 module.exports = settings => {
@@ -18,7 +19,13 @@ module.exports = settings => {
   };
 
   router.get('/ready', (req, res) => {
-    const services = [settings.api, settings.workflow];
+    const services = [
+      settings.api,
+      settings.workflow,
+      settings.notifications,
+      settings.emailer,
+      get(settings, 'auth.permissions')
+    ];
     Promise.all(services.map(ping))
       .then(responses => {
         const down = responses.filter(Boolean);

--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -21,7 +21,7 @@ module.exports = settings => {
       });
   };
 
-  router.get('/ready', (req, res) => {
+  router.get('/ready', (req, res, next) => {
     const services = [
       settings.api,
       settings.workflow,
@@ -41,7 +41,8 @@ module.exports = settings => {
         } else {
           res.json({ status: 'ok' });
         }
-      });
+      })
+      .catch(next);
   });
 
   router.get('/', (req, res) => {

--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -1,17 +1,43 @@
 const fetch = require('r2');
+const { Router } = require('express');
 
-module.exports = settings => (req, res) => {
-  if (settings.api) {
-    return fetch(`${settings.api}/healthcheck`)
+module.exports = settings => {
+  const router = Router();
+
+  const ping = url => {
+    if (!url) {
+      return false;
+    }
+    return fetch(`${url}/healthcheck`)
       .then(response => {
         if (response.status !== 200) {
+          return { url, status: response.status };
+        }
+        return false;
+      });
+
+  }
+
+  router.get('/ready', (req, res) => {
+    const services = [settings.api, settings.workflow];
+    Promise.all(services.map(ping))
+      .then(responses => {
+        const down = responses.filter(Boolean);
+        if (down.length) {
           res.status(500);
           res.json({
             status: 'failed',
-            message: `Could not connect to downstream API at ${settings.api}`
+            down
           });
+        } else {
+          res.json({ status: 'ok' });
         }
       });
-  }
-  res.json({ status: 'ok' });
+  });
+
+  router.get('*', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  return router;
 };

--- a/ui/router.js
+++ b/ui/router.js
@@ -45,7 +45,6 @@ module.exports = settings => {
     transformViews: false
   }));
 
-  app.get('/healthcheck', healthcheck(settings));
 
   app.use(staticrouter);
 
@@ -57,7 +56,6 @@ module.exports = settings => {
   app.use('/ho', express.static(homeOffice.assets));
 
   app.use(cacheControl(settings));
-  app.use(logger(settings));
 
   if (settings.session) {
     app.use(session(settings.session));
@@ -65,6 +63,11 @@ module.exports = settings => {
       req.session.destroy(() => next());
     });
   }
+
+  app.get('/healthcheck', healthcheck(settings));
+
+  app.use(logger(settings));
+
   if (settings.auth) {
     const keycloak = auth(Object.assign({ store: new MemoryStore() }, settings.auth));
     app.use(keycloak.middleware());

--- a/ui/router.js
+++ b/ui/router.js
@@ -45,7 +45,6 @@ module.exports = settings => {
     transformViews: false
   }));
 
-
   app.use(staticrouter);
 
   if (settings.assets) {
@@ -64,7 +63,7 @@ module.exports = settings => {
     });
   }
 
-  app.get('/healthcheck', healthcheck(settings));
+  app.use('/healthcheck', healthcheck(settings));
 
   app.use(logger(settings));
 


### PR DESCRIPTION
Serve two endpoints, one for liveness (if this starts to fail then k8s will kill and restart the pod) and one for readiness (if this fails then k8s will stop routing traffic.

The latter should check downstream services are available.