### PR TITLE
Remove emailer and notifications service from readiness check

### DIFF
--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -25,8 +25,6 @@ module.exports = settings => {
     const services = [
       settings.api,
       settings.workflow,
-      settings.notifications,
-      settings.emailer,
       get(settings, 'auth.permissions')
     ];
     Promise.all(services.map(ping))


### PR DESCRIPTION
The vast majority of the service is usable without these, so thy shouldn't bring down the whole stack if they're missing.