### PR TITLE
Only log 5xx range errors

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -4,7 +4,7 @@ module.exports = settings => {
   return (error, req, res, next) => {
     error.status = error.status || 500;
     res.status(error.status);
-    if (req.log) {
+    if (req.log && error.status > 499) {
       req.log('error', { ...error, message: error.message, stack: error.stack });
     }
 


### PR DESCRIPTION
The logs add a full stack for 404 errors, which is just noisy. Stop that.