### PR TITLE
Use reduced babel configuration for babel-register

### DIFF
--- a/.babelrc.server.json
+++ b/.babelrc.server.json
@@ -1,0 +1,16 @@
+{
+  "presets": [
+    "@babel/preset-react",
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": 10
+        }
+      }
+    ]
+  ],
+  "plugins": [
+    "transform-class-properties"
+  ]
+}

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,4 +1,4 @@
-const babelrc = require('../.babelrc.json');
+const babelrc = require('../.babelrc.server.json');
 
 require('@babel/register')({
   ...babelrc,


### PR DESCRIPTION
We don't need rest-spread or browser compat transforms for server code, so use a reduced configuration for server compiling.