### PR TITLE
Allow inline styles when a nonce is provided

### DIFF
--- a/lib/get-content-security-policy.js
+++ b/lib/get-content-security-policy.js
@@ -4,7 +4,7 @@ const getContentSecurityPolicy = config => {
   const csp = config.csp || [];
   const directives = {
     defaultSrc: [`'none'`],
-    styleSrc: [`'self'`],
+    styleSrc: [`'self'`, (req, res) => `'nonce-${res.locals.static.nonce}'`, "'unsafe-inline'"],
     imgSrc: [`'self' data:`],
     fontSrc: [`'self'`, 'data:'],
     connectSrc: [`'self'`],


### PR DESCRIPTION
Helps when debugging pdf rendering.

