### PR TITLE
Prevent setting status code back to error object

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -2,13 +2,13 @@ const ErrorComponent = require('../ui/views/error');
 
 module.exports = settings => {
   return (error, req, res, next) => {
-    error.status = error.status || 500;
-    res.status(error.status);
-    if (req.log && error.status > 499) {
-      req.log('error', { ...error, message: error.message, stack: error.stack });
+    const status = error.status || 500;
+    res.status(status);
+    if (req.log && status > 499) {
+      req.log('error', { ...error, status, message: error.message, stack: error.stack });
     }
 
-    if (!settings.verboseErrors && error.status > 499) {
+    if (!settings.verboseErrors && status > 499) {
       error.message = 'Something went wrong';
       error.stack = null;
     }


### PR DESCRIPTION
This is causing some errors to throw in prod, which swallows the original error insted of logging and rendering an error page.