### PR TITLE
Allow error handler to be used in non-jsx contexts

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,5 +1,3 @@
-const ErrorComponent = require('../ui/views/error');
-
 module.exports = settings => {
   return (error, req, res, next) => {
     const status = error.status || 500;
@@ -13,8 +11,8 @@ module.exports = settings => {
       error.stack = null;
     }
 
-    if (req.accepts('html')) {
-      const Component = error.template || ErrorComponent;
+    if (req.accepts('html') && settings.template) {
+      const Component = error.template || settings.template;
       return res.render(res.layout || settings.layout || 'layout', {
         Component: Component.default || Component,
         scripts: [],

--- a/ui/router.js
+++ b/ui/router.js
@@ -22,6 +22,7 @@ const notifications = require('../lib/middleware/notifications');
 const cacheControl = require('../lib/middleware/cache-control');
 
 const privacy = require('./pages/privacy');
+const ErrorComponent = require('./views/error');
 
 module.exports = settings => {
 
@@ -126,7 +127,10 @@ module.exports = settings => {
     res.sendResponse();
   });
 
-  app.use(errorHandler(settings));
+  app.use(errorHandler({
+    ...settings,
+    template: ErrorComponent
+  }));
 
   const _app = (...args) => app(...args);
 


### PR DESCRIPTION
Currently trying to use the default error handler in contexts where jsx rendering is not supported fails because it can't require the default template.

Instead pass the default template in as an optionin known UI contexts so the default error handler can be used for all services.