### PR TITLE
Use base64 encoding of INITIAL_STATE to prevent html breaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1884,6 +1884,11 @@
         }
       }
     },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -7524,11 +7529,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
-    },
-    "striptags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
-      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@lennym/redis-session": "^1.0.4",
     "@ukhomeoffice/frontend-toolkit": "^2.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "base-64": "^0.1.0",
     "body-parser": "^1.18.3",
     "express": "^4.16.2",
     "express-react-views": "^0.11.0",
@@ -52,7 +53,6 @@
     "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
-    "striptags": "^3.1.1",
     "terser-webpack-plugin": "^1.2.3",
     "uuid": "^3.3.2",
     "winston": "^3.2.1"

--- a/ui/store.js
+++ b/ui/store.js
@@ -25,4 +25,4 @@ if (process.env.NODE_ENV === 'development') {
   middleware.push(logger);
 }
 
-module.exports = createStore(rootReducer, window.INITIAL_STATE, applyMiddleware(...middleware));
+module.exports = createStore(rootReducer, JSON.parse(window.atob(window.INITIAL_STATE)), applyMiddleware(...middleware));

--- a/ui/views/base.jsx
+++ b/ui/views/base.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import omit from 'lodash/omit';
-import striptags from 'striptags';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
+import base64 from 'base-64';
 import HomeOffice from '../components/home-office';
 import rootReducer from '../reducers';
 import {
@@ -18,13 +18,6 @@ const renderChildren = (children, wrap) => {
     return <Wrapper>{ children }</Wrapper>;
   }
   return children;
-};
-
-const encodeEntities = (key, value) => {
-  if (typeof value === 'string') {
-    return striptags(value);
-  }
-  return value;
 };
 
 const Layout = ({
@@ -83,7 +76,7 @@ const Layout = ({
         </main>
       </div>
       {
-        wrap && <script nonce={nonce} dangerouslySetInnerHTML={{__html: `window.INITIAL_STATE=${JSON.stringify(store.getState(), encodeEntities)};`}} />
+        wrap && <script nonce={nonce} dangerouslySetInnerHTML={{__html: `window.INITIAL_STATE='${base64.encode(JSON.stringify(store.getState()))}';`}} />
       }
     </HomeOffice>
   );


### PR DESCRIPTION
The previous tactic of using `striptags` to remove html-like content and prevent the page source breaking when using `dangerouslySetInnerHtml` had the unfortunate side-effect of removing legitimate content from users' data. In particularly any combination of less-than and greater-than symbols in a PPL application would result in removal of all content in between.

Instead base64 encode the complete JSON and then decode on the client. This allows for legitimate html-like content in PPL applications, but removes the risk of that breaking the initial page render.