### PR TITLE
Decode when setting INITIAL_STATE

### DIFF
--- a/ui/store.js
+++ b/ui/store.js
@@ -25,4 +25,4 @@ if (process.env.NODE_ENV === 'development') {
   middleware.push(logger);
 }
 
-module.exports = createStore(rootReducer, JSON.parse(window.atob(window.INITIAL_STATE)), applyMiddleware(...middleware));
+module.exports = createStore(rootReducer, window.INITIAL_STATE, applyMiddleware(...middleware));

--- a/ui/views/base.jsx
+++ b/ui/views/base.jsx
@@ -76,7 +76,10 @@ const Layout = ({
         </main>
       </div>
       {
-        wrap && <script nonce={nonce} dangerouslySetInnerHTML={{__html: `window.INITIAL_STATE='${base64.encode(JSON.stringify(store.getState()))}';`}} />
+        wrap && <script nonce={nonce} dangerouslySetInnerHTML={{__html: `
+          function decode(str) { return JSON.parse(window.atob(str)); }
+          window.INITIAL_STATE=decode('${base64.encode(JSON.stringify(store.getState()))}');
+        `}} />
       }
     </HomeOffice>
   );


### PR DESCRIPTION
Instead of decoding when reading from the variable - and therefore needing to do so in multiple places - decode the base64 encoded JSON at the point of setting the `INITIAL_STATE` variable.

This results in a non-breaking change since any implementations relying on the value of `window.INITIAL_STATE` are unchanged.