### PR TITLE
Use utf8 compatible base64 encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1884,11 +1884,6 @@
         }
       }
     },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
-    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@lennym/redis-session": "^1.0.4",
     "@ukhomeoffice/frontend-toolkit": "^2.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "base-64": "^0.1.0",
     "body-parser": "^1.18.3",
     "express": "^4.16.2",
     "express-react-views": "^0.11.0",

--- a/ui/views/base.jsx
+++ b/ui/views/base.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import omit from 'lodash/omit';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import base64 from 'base-64';
 import HomeOffice from '../components/home-office';
 import rootReducer from '../reducers';
 import {
@@ -78,7 +77,7 @@ const Layout = ({
       {
         wrap && <script nonce={nonce} dangerouslySetInnerHTML={{__html: `
           function decode(str) { return JSON.parse(window.atob(str)); }
-          window.INITIAL_STATE=decode('${base64.encode(JSON.stringify(store.getState()))}');
+          window.INITIAL_STATE=decode('${Buffer.from(JSON.stringify(store.getState()), 'utf8').toString('base64')}');
         `}} />
       }
     </HomeOffice>


### PR DESCRIPTION
The `base-64` library only supports Latin1 encoding, which causes some "special" characters to throw errors when base64 encoding them down to the client.