### PR TITLE
Strip session tokens from bookmarked URLs

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -1,5 +1,6 @@
 const Keycloak = require('keycloak-connect');
-const {Router} = require('express');
+const { Router } = require('express');
+const { isEmpty } = require('lodash');
 
 const can = require('./can');
 const Profile = require('./profile');
@@ -31,6 +32,9 @@ module.exports = settings => {
   });
 
   keycloak.accessDenied = (req, res, next) => {
+    if (!isEmpty(req.query)) {
+      return res.redirect(req.path);
+    }
     const e = new Error('Access Denied');
     e.status = 403;
     next(e);


### PR DESCRIPTION
If someone bookmarks a url with a session token or auth code in it then they will be thrown an Unauthorised error rather than being redirected to the login screen (or logged-in page - as appropriate).

If an auth error occurs and there are query-string parameters then remove them and redirect to the root page.