### PR TITLE
Include user id in log output

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,7 @@
 const winston = require('winston');
 const morgan = require('morgan');
 const { Router } = require('express');
+const { get } = require('lodash');
 
 module.exports = settings => {
 
@@ -23,7 +24,9 @@ module.exports = settings => {
     write: msg => logger.log('info', msg)
   };
 
-  router.use(morgan(options.format, { stream: logger.stream }));
+  morgan.token('user', req => get(req, 'user.profile.id'));
+
+  router.use(morgan(`${morgan.short} - :user`, { stream: logger.stream }));
   router.use((req, res, next) => {
     req.log = (level, msg) => {
       if (msg === undefined) {


### PR DESCRIPTION
This allows better debugging or services by allowing tracing particular users through the logs.