### PR TITLE
Don't babel compile non-jsx unless it's in projects

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -3,9 +3,9 @@ const babelrc = require('../.babelrc.server.json');
 require('@babel/register')({
   ...babelrc,
   ignore: [
-    // ignore files that are not .jsx unless they're in an @asl scoped dependency
-    // skip `asl-*` to cover the case when that is linked
-    p => !p.match(/.jsx/) && !p.match(/@asl/) && !p.match(/\/asl-/),
+    // ignore files that are not .jsx unless they're in @asl/projects
+    // skip `asl-projects` to cover the case when that is linked
+    p => !p.match(/.jsx/) && !p.match(/@asl\/projects/) && !p.match(/\/asl-projects/),
     // ignore node modules that are not @asl owned dependencies
     p => p.match(/node_modules/) && !(p.match(/@joefitter\/docx/) || p.match(/@asl/))
   ]


### PR DESCRIPTION
The only place we have .js files that need to be babel-ed is in projects, and compiling _everything_ adds a lot of extra time to the startup of the UI processes.

Filter out things that don't need compiling a little more aggressively so the startup time is improved.