### PR TITLE
Log unhandled exceptions

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -11,7 +11,8 @@ module.exports = settings => {
 
   const transports = [
     new winston.transports.Console({
-      level: options.level || 'info'
+      level: options.level || 'info',
+      handleExceptions: true
     })
   ];
 


### PR DESCRIPTION
Currently if an unhandled error occurs, causing the service to crash then it won't be logged and no information can be gathered after the fact.

Use winston's built-in behaviour to automatically log error data on unhandled exceptions before exiting.