### PR TITLE
Log all errors

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -5,12 +5,12 @@ module.exports = settings => {
   return (error, req, res, next) => {
     const status = error.status || 500;
     res.status(status);
-    if (req.log && status > 499) {
+    if (typeof req.log === 'function') {
       req.log('error', {
         ...error,
         status,
         message: error.message,
-        stack: error.stack,
+        stack: status > 499 && error.stack,
         method: req.method,
         url: req.originalUrl
       });


### PR DESCRIPTION
Rather than suppressing logging of 4xx range errors, log everything and allow downstream log consumers to filter it.

Remove the `stack` from 4xx range errors though as it's a lot of noice for not a lot of value.