### PR TITLE
Log all error parameters by default

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -8,12 +8,12 @@ module.exports = settings => {
     res.status(status);
     if (typeof req.log === 'function') {
       req.log('error', {
-        ...error,
-        status,
+        url: req.originalUrl,
+        method: req.method,
         message: error.message,
         stack: error.stack,
-        method: req.method,
-        url: req.originalUrl
+        status,
+        ...error
       });
     }
     if (settings.errorEvent) {


### PR DESCRIPTION
If the error object has `url` or `method` params sent by the client then use those in preference to local versions.