### PR TITLE
Don't overwrite provided establishment

### DIFF
--- a/lib/middleware/permissions.js
+++ b/lib/middleware/permissions.js
@@ -2,7 +2,7 @@ const { UnauthorisedError } = require('../../errors');
 
 module.exports = (task, params = {}) => {
   return (req, res, next) => {
-    req.user.can(task, Object.assign({}, req.params, params, { establishment: req.establishmentId }))
+    req.user.can(task, Object.assign({}, req.params, { establishment: req.establishmentId }, params))
       .then(allowed => {
         return allowed ? next() : next(new UnauthorisedError());
       });


### PR DESCRIPTION
* Establishment is sometimes relevant to the model and can be different from the one held in req.params. In particular viewing a PIL at a different establishment