### PR TITLE
Handle wildcards in route builder

### DIFF
--- a/lib/middleware/route-builder.js
+++ b/lib/middleware/route-builder.js
@@ -8,6 +8,9 @@ const replace = params => fragment => {
     }
     return params[fragment.substr(1)];
   }
+  if (fragment === '*') {
+    return '';
+  }
   return fragment;
 };
 


### PR DESCRIPTION
If a route is mounted on `/*` then don't include the asterisk when routing to it in the route builder.