### PR TITLE
Log errors directly to stdout if `req.log` not available

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -6,15 +6,18 @@ module.exports = settings => {
   return (error, req, res, next) => {
     const status = error.status || 500;
     res.status(status);
+    const params = {
+      url: req.originalUrl,
+      method: req.method,
+      message: error.message,
+      stack: error.stack,
+      status,
+      ...error
+    };
     if (typeof req.log === 'function') {
-      req.log('error', {
-        url: req.originalUrl,
-        method: req.method,
-        message: error.message,
-        stack: error.stack,
-        status,
-        ...error
-      });
+      req.log('error', params);
+    } else {
+      console.error(JSON.stringify({ ...params, type: 'UNHANDLED_LOGGING' }));
     }
     if (settings.errorEvent) {
       const event = `${settings.errorEvent}.${status}`;


### PR DESCRIPTION
Sysdig is reporting error events, but nothing is being logged, and this is the only possible reason I can think of - something is throwing before the logger is initialised and mounted.

Fallback to `console.error` in those cases.