### PR TITLE
Omit `args` from error logs

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,5 +1,6 @@
 const ClientError = require('../errors/client-error');
 const StatsD = require('hot-shots');
+const omit = require('lodash/omit');
 
 module.exports = settings => {
   const stats = new StatsD();
@@ -12,7 +13,8 @@ module.exports = settings => {
       message: error.message,
       stack: error.stack,
       status,
-      ...error
+      // omit args from redis errors because they contain mixed data types which can break elasticsearch's indexing
+      ...omit(error, 'args')
     };
     if (typeof req.log === 'function') {
       req.log('error', params);


### PR DESCRIPTION
Kibana has had issues ingesting some logs from redis errors because it uses dynamic indexing on json log fields based on type.

This means that if log entries contains fields of inconsistent types then the indexer can fail on subsequent log entries and prevent them from being ingested.

This has occurred a few times in the last few days specifically around the `args` property on a redis error. Remove that property from any errors before logging to prevent indexing issues.