### PR TITLE
Add optional `pageTitle` property to prefix `document.title`

### DIFF
--- a/ui/views/base.jsx
+++ b/ui/views/base.jsx
@@ -54,6 +54,7 @@ const Layout = ({
   }
   const page = (
     <HomeOffice
+      title={props.pageTitle ? `${props.pageTitle} - ${siteTitle}` : siteTitle}
       propositionHeader={siteTitle}
       stylesheets={['/public/css/app.css'].concat(stylesheets)}
       scripts={scripts}


### PR DESCRIPTION
If a page sets `res.locals.pageTitle` then it will prefix the default title "Research and testing using animals" with wahtever value is set.