### PR TITLE
Refresh authentication tokens if they are expiring shortly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "10.1.5",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.1.5.tgz",
-      "integrity": "sha1-IQ9oDelzdfvSWlgjakDxwFEBFmk=",
+      "version": "10.11.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.11.0.tgz",
+      "integrity": "sha1-eXqQ6MKRMwo18VgGLR06QcAP59M=",
       "requires": {
-        "@asl/constants": "^0.8.3",
+        "@asl/constants": "^1.0.0",
         "@asl/dictionary": "^1.1.5",
-        "@ukhomeoffice/react-components": "^0.9.4",
+        "@ukhomeoffice/react-components": "^0.10.1",
         "accessible-autocomplete": "^2.0.3",
         "babel-plugin-transform-class-properties": "^6.24.1",
         "classnames": "^2.2.6",
@@ -24,13 +24,14 @@
         "react-markdown": "^6.0.2",
         "react-redux": "^7.1.0",
         "redux": "^4.0.1",
-        "url": "^0.11.0"
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -50,79 +51,36 @@
             "has-symbols": "^1.0.1"
           }
         },
-        "is-buffer": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-        },
         "mustache": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
           "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA=="
         },
         "object-inspect": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
         },
         "qs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
           "requires": {
             "side-channel": "^1.0.4"
           }
         },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        },
-        "react-markdown": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-6.0.2.tgz",
-          "integrity": "sha512-Et2AjXAsbmPP1nLQQRqmVgcqzfwcz8uQJ8VAdADs8Nk/aaUA0YeU9RDLuCtD+GwajCnm/+Iiu2KPmXzmD/M3vA==",
-          "requires": {
-            "@types/hast": "^2.0.0",
-            "@types/unist": "^2.0.3",
-            "comma-separated-tokens": "^1.0.0",
-            "prop-types": "^15.7.2",
-            "property-information": "^5.0.0",
-            "react-is": "^17.0.0",
-            "remark-parse": "^9.0.0",
-            "remark-rehype": "^8.0.0",
-            "space-separated-tokens": "^1.1.0",
-            "style-to-object": "^0.3.0",
-            "unified": "^9.0.0",
-            "unist-util-visit": "^2.0.0",
-            "vfile": "^4.0.0"
-          }
-        },
         "redux": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
-          "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+          "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
           "requires": {
             "@babel/runtime": "^7.9.2"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        },
-        "remark-parse": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-          "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-          "requires": {
-            "mdast-util-from-markdown": "^0.8.0"
-          }
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         },
         "side-channel": {
           "version": "1.0.4",
@@ -133,78 +91,13 @@
             "get-intrinsic": "^1.0.2",
             "object-inspect": "^1.9.0"
           }
-        },
-        "unified": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
-          "integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-buffer": "^2.0.0",
-            "is-plain-obj": "^2.0.0",
-            "trough": "^1.0.0",
-            "vfile": "^4.0.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
-        },
-        "unist-util-stringify-position": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-          "requires": {
-            "@types/unist": "^2.0.2"
-          }
-        },
-        "unist-util-visit": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0",
-            "unist-util-visit-parents": "^3.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0"
-          }
-        },
-        "vfile": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-          "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "unist-util-stringify-position": "^2.0.0",
-            "vfile-message": "^2.0.0"
-          }
-        },
-        "vfile-message": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-stringify-position": "^2.0.0"
-          }
         }
       }
     },
     "@asl/constants": {
-      "version": "0.8.3",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.8.3.tgz",
-      "integrity": "sha1-gW7wVmjh0iYAR80TSltCHgYC/7Q="
+      "version": "1.1.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-1.1.1.tgz",
+      "integrity": "sha1-tpf5rlGiq8kR/JE8LFqYX+3EXdo="
     },
     "@asl/dictionary": {
       "version": "1.1.5",
@@ -1387,122 +1280,12 @@
       }
     },
     "@ukhomeoffice/react-components": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.9.4.tgz",
-      "integrity": "sha512-thRHKKRenPTO74MmrCiFQLlcC5OfQ2xbGLtG6ey0FYMNkx4fz48d3kA1wc8rIR5CSuWlv1Dk9p0JbzJetmjvPQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.10.3.tgz",
+      "integrity": "sha512-xuyDo6OQyuzgoBunzZEx9+qPfd6hOvD3ZgrR3qr4o26bRIBcvI94TxqJQ/d43iCIl7grLgfCucuPcd5ebpE/zg==",
       "requires": {
         "classnames": "^2.2.6",
         "react-markdown": "^6.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        },
-        "react-markdown": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-6.0.2.tgz",
-          "integrity": "sha512-Et2AjXAsbmPP1nLQQRqmVgcqzfwcz8uQJ8VAdADs8Nk/aaUA0YeU9RDLuCtD+GwajCnm/+Iiu2KPmXzmD/M3vA==",
-          "requires": {
-            "@types/hast": "^2.0.0",
-            "@types/unist": "^2.0.3",
-            "comma-separated-tokens": "^1.0.0",
-            "prop-types": "^15.7.2",
-            "property-information": "^5.0.0",
-            "react-is": "^17.0.0",
-            "remark-parse": "^9.0.0",
-            "remark-rehype": "^8.0.0",
-            "space-separated-tokens": "^1.1.0",
-            "style-to-object": "^0.3.0",
-            "unified": "^9.0.0",
-            "unist-util-visit": "^2.0.0",
-            "vfile": "^4.0.0"
-          }
-        },
-        "remark-parse": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-          "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-          "requires": {
-            "mdast-util-from-markdown": "^0.8.0"
-          }
-        },
-        "unified": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
-          "integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-buffer": "^2.0.0",
-            "is-plain-obj": "^2.0.0",
-            "trough": "^1.0.0",
-            "vfile": "^4.0.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
-        },
-        "unist-util-stringify-position": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-          "requires": {
-            "@types/unist": "^2.0.2"
-          }
-        },
-        "unist-util-visit": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0",
-            "unist-util-visit-parents": "^3.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0"
-          }
-        },
-        "vfile": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-          "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "unist-util-stringify-position": "^2.0.0",
-            "vfile-message": "^2.0.0"
-          }
-        },
-        "vfile-message": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-stringify-position": "^2.0.0"
-          }
-        }
       }
     },
     "@ungap/promise-all-settled": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-service#readme",
   "dependencies": {
-    "@asl/components": "^10.1.5",
+    "@asl/components": "^10.11.0",
     "@babel/core": "^7.4.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/preset-env": "^7.4.4",


### PR DESCRIPTION
If an access token is valid but only has a very short period remaining before expiry it can end up being used for downstream requests post-expiry causing unexpected failures.

When a token has less than 30 seconds remaining before expiry then attempt to refresh it and use the updated token instead. Concurrent requests will fail refresh, due to refresh tokens only being usable once, so are allowed to continue with the existing access token if the refresh fails. It is expected that 30 seconds will be sufficient time for all concurrent requests to resolve.