### PR TITLE
Fix `token` vs `access_token` inconsistency

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -55,7 +55,7 @@ module.exports = settings => {
         const remaining = req.kauth.grant.access_token.content.exp * 1000 - Date.now();
         const user = {
           id: req.kauth.grant.access_token.content.sub,
-          token: req.kauth.grant.access_token.token
+          access_token: req.kauth.grant.access_token.token
         };
         // if token is less than 30s away from expiring then refresh it
         if (remaining < 30 * 1000 && req.kauth.grant.refresh_token) {
@@ -77,7 +77,7 @@ module.exports = settings => {
                 keycloak.storeGrant(grant, req, res);
                 return {
                   ...user,
-                  token: grant.access_token
+                  access_token: grant.access_token
                 };
               }
               return user;
@@ -86,11 +86,8 @@ module.exports = settings => {
         return user;
       })
       .then(user => {
-        req.user = {
-          id: user.id,
-          access_token: user.token
-        };
-        return getProfile(user, req.session);
+        req.user = user;
+        return getProfile(req.user, req.session);
       })
       .then(profile => {
         Object.assign(req.user, {

--- a/lib/auth/profile.js
+++ b/lib/auth/profile.js
@@ -23,7 +23,7 @@ module.exports = (endpoint) => {
         }
 
         const headers = {
-          Authorization: `bearer ${user.token}`
+          Authorization: `bearer ${user.access_token}`
         };
 
         return request(`/me`, { headers })


### PR DESCRIPTION
The user object was being used inconsistently in different contexts, where some had the token stored in `user.token` and others in `user.access_token`. This meant that the `user.refreshProfile` function was being called without the access token available as it expected the property to be `token` where it was in fact `access_token`. This meant that all POST or PUT requests failed with a 403.

Standardise on `access_token` everywhere.