### PR TITLE
Initialise keycloak grant before storing

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -72,6 +72,7 @@ module.exports = settings => {
               return request(`${settings.url}/realms/${settings.realm}/protocol/openid-connect/token`, opts).response;
             })
             .then(response => response.json())
+            .then(grant => keycloak.grantManager.createGrant(grant))
             .then(grant => {
               if (grant.access_token) {
                 keycloak.storeGrant(grant, req, res);


### PR DESCRIPTION
The `createGrant` function sets the `__raw` property on the grant object, which is then saved to the session.

By not initialising this way we were effectively deleting the grant from the session when attempting to store it, which is fine when doing full page reloads, but in journeys which involve background requests (i.e. doing anything with PPLs) was forcing a full page refresh whenever the token expired.