### PR TITLE
Store only the token on req.user.access_token

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -78,7 +78,7 @@ module.exports = settings => {
                 keycloak.storeGrant(grant, req, res);
                 return {
                   ...user,
-                  access_token: grant.access_token
+                  access_token: grant.access_token.token
                 };
               }
               return user;


### PR DESCRIPTION
Now the grant token is normalised through `createGrant` the structure changed slightly so the raw token is now at `access_token.token`, and not just `access_token`.