### PR TITLE
Update npmrc to use new artifactory token

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -5,10 +5,8 @@ steps:
   - name: install
     image: node:18
     environment:
-      NPM_AUTH_USERNAME:
-        from_secret: npm_auth_username
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
@@ -16,10 +14,8 @@ steps:
   - name: test
     image: node:18
     environment:
-      NPM_AUTH_USERNAME:
-        from_secret: npm_auth_username
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
@@ -27,10 +23,8 @@ steps:
   - name: publish
     image: node:18
     environment:
-      NPM_AUTH_USERNAME:
-        from_secret: npm_auth_username
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:

--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,8 @@
-@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/
+registry=https://registry.npmjs.org/
+
 @ukhomeoffice:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}
 
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:username=${NPM_AUTH_USERNAME}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_password=${NPM_AUTH_TOKEN}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:email=leonard.martin@digital.homeoffice.gov.uk
+@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/
+//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_authToken=${ART_AUTH_TOKEN}
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:always-auth=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/service",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/service",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/service",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4304

Lenny's creds no longer work for publishing to artifactory npm. This replaces his credentials with one provided by ACP.