### PR TITLE
[ASL-4703] Fix squashed status-bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/service",
-  "version": "10.6.0",
+  "version": "10.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/service",
-      "version": "10.6.0",
+      "version": "10.6.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
@@ -17,7 +17,7 @@
         "@babel/register": "^7.23.7",
         "@lennym/redis-session": "^2.2.0",
         "@redux-devtools/extension": "^3.3.0",
-        "@ukhomeoffice/asl-components": "13.8.0",
+        "@ukhomeoffice/asl-components": "13.9.1",
         "@ukhomeoffice/frontend-toolkit": "^3.0.0",
         "aws-sdk": "^2.1370.0",
         "babel-plugin-transform-require-ignore": "^0.1.1",
@@ -2526,18 +2526,20 @@
       "license": "MIT"
     },
     "node_modules/@ukhomeoffice/asl-components": {
-      "version": "13.8.0",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.8.0/d669a63a6772897973373a1cc1d26cf7c009cb02",
-      "integrity": "sha512-YCMlT0Z0l4FmHfTTVHDJEHPRfEhkOFLQ4vRywnwYkbQPwTeGBEqjTJkKPLpkGg/UAjunNKaQpgKJaaIUe/9iVA==",
+      "version": "13.9.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.1/02150810d650f014a69956292dd76eea58feb8d4",
+      "integrity": "sha512-8yoEun4qgQdgjaUlcSbEEBVprdQeqtPV1KSkHF3iqopB7XFwqVDW6g7VaG45kXWMVQVIhDOAa79u5HUOUKaEbg==",
       "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "^2.2.0",
         "@ukhomeoffice/asl-dictionary": "^2.1.0",
         "@ukhomeoffice/react-components": "^1.3.3",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
         "accessible-autocomplete": "^2.0.3",
         "classnames": "^2.2.6",
         "date-fns": "^3.6.0",
         "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "mustache": "^3.0.1",
@@ -2550,6 +2552,45 @@
         "shasum": "^1.0.2",
         "url": "^0.11.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@ukhomeoffice/asl-components/node_modules/@x-govuk/govuk-prototype-components": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-3.0.9.tgz",
+      "integrity": "sha512-SvYSaeM465IEKZFRLO244FAZqP0GPyoWkq6m5LNIsfudYFAyd16BRQBQktY9t/TUOx1HRpGJJi2WZeqyVKRxkw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessible-autocomplete": "^3.0.0",
+        "eventslibjs": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "govuk-frontend": "^5.0.0"
+      }
+    },
+    "node_modules/@ukhomeoffice/asl-components/node_modules/@x-govuk/govuk-prototype-components/node_modules/accessible-autocomplete": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz",
+      "integrity": "sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ukhomeoffice/asl-components/node_modules/govuk-frontend": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
+      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.2.0"
       }
     },
     "node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
@@ -5392,6 +5433,12 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/eventslibjs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventslibjs/-/eventslibjs-1.2.0.tgz",
+      "integrity": "sha512-nui7FHXHeeZjWkQ1dZ4R3RchkT+164+y1/puiOY1Zc3CPU9W8XzAzdhqvuVQ4EJt7F/W94O5U26/oVFpBOPY3w==",
+      "license": "MIT"
     },
     "node_modules/express": {
       "version": "4.21.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/service",
-  "version": "10.6.0",
+  "version": "10.6.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.1",
     "@babel/register": "^7.23.7",
     "@lennym/redis-session": "^2.2.0",
-    "@ukhomeoffice/asl-components": "13.8.0",
+    "@ukhomeoffice/asl-components": "13.9.1",
     "@ukhomeoffice/frontend-toolkit": "^3.0.0",
     "aws-sdk": "^2.1370.0",
     "babel-plugin-transform-require-ignore": "^0.1.1",

--- a/ui/components/home-office.jsx
+++ b/ui/components/home-office.jsx
@@ -43,11 +43,11 @@ class HomeOffice extends React.Component {
                     }
                   </div>
               }
-              <div className="content">
-                {
-                  this.props.headerContent && this.props.headerContent
-                }
-              </div>
+
+              {
+                this.props.headerContent && this.props.headerContent
+              }
+
             </div>
           </header>
 


### PR DESCRIPTION
`@include govuk-grid-column(one-third);` uses % based width in newer govuk design system, so needs to be at the top level of the header, not nested in a content div